### PR TITLE
Cgroup.systemd

### DIFF
--- a/sh/rc-cgroup.sh.in
+++ b/sh/rc-cgroup.sh.in
@@ -72,6 +72,14 @@ cgroup_set_values()
 
 cgroup_set_limits()
 {
+    # relocate starting process to the top of the cgroup
+    # it prevents from unwanted inheriting of the user
+    # cgroups. But may lead to a problems where that inheriting
+    # is needed.
+	for d in /sys/fs/cgroup/* ; do
+		echo $$ > "${d}"/tasks
+	done
+
 	openrc_cgroup=/sys/fs/cgroup/openrc
 	if [ -d "$openrc_cgroup" ]; then
 		cgroup="$openrc_cgroup/$RC_SVCNAME"


### PR DESCRIPTION
This is patch that fixes situation with logind

   https://bugs.gentoo.org/show_bug.cgi?id=475194

Also it fixes other unneeded inheriting, as new service will inherit all user cgroups unless they are explicitly set, that may lead to incorrect limits setting and even a bug with some programs.

The patch is not yet complete as it will break a systems that require inheriting (that may be a some kind
of logging controllers) but I don't know any concrete example.

Patch is done on the top of git.overlays.gentoo.org repo, as it uses another approach (not the one is used in master), so I'd prefer to clean/undo last commits in master but I have to rights for that.
