### PR TITLE
Add lxc keywork for devfs script.

### DIFF
--- a/init.d/devfs.in
+++ b/init.d/devfs.in
@@ -7,7 +7,7 @@ description="Mount system critical filesystems in /dev."
 depend() {
 	use dev-mount
 	before dev
-	keyword -prefix -vserver
+	keyword -prefix -vserver -lxc
 }
 
 start() {


### PR DESCRIPTION
Devfs is not needed for LXC, as LXC mounts all required fs on
it's own. Reported by specing.
