### PR TITLE
Added uml keyword to fsck service.

### DIFF
--- a/init.d/fsck.in
+++ b/init.d/fsck.in
@@ -9,7 +9,7 @@ _IFS="
 depend()
 {
 	use dev clock modules
-	keyword -jail -openvz -prefix -timeout -vserver -lxc
+	keyword -jail -openvz -prefix -timeout -vserver -lxc -uml
 }
 
 _abort() {


### PR DESCRIPTION
Fix relevant an issue mentioned by Toralf Förster.

X-Gentoo-Bug: #481096.
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=481096
