### PR TITLE
network.in: skip loopback device

### DIFF
--- a/init.d/network.in
+++ b/init.d/network.in
@@ -46,7 +46,11 @@ sys_interfaces()
 		local w= rest= i= cmd=$1
 		while read w rest; do
 			i=${w%%:*}
-			[ "$i" != "$w" ] || continue
+			case "$i" in
+				"$w") continue ;;
+				lo|lo0) continue ;;
+				*) ;;
+			esac
 			if [ "$cmd" = u ]; then
 				ifconfig "$i" | grep -q "[ ]*UP" || continue
 			fi


### PR DESCRIPTION
The loopback interface is supposed to be handled by the loopback
service, but sys_interfaces includes it.  This causes network to try to
start it and means that network provides net even if lo is the only
interface configured.

The loopback interface probably needs to be grep'd out of the ifconfig output for the BSD branch of sys_interfaces as well, but I don't have access to a BSD system to test.
