### PR TITLE
Later loop detector: anti-hang up on boot

### DIFF
--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -361,7 +361,7 @@ get_provided(const RC_DEPINFO *depinfo, const char *runlevel, int options)
 	return providers;
 }
 
-static void
+static int
 visit_service(const RC_DEPTREE *deptree,
 	      const RC_STRINGLIST *types,
 	      RC_STRINGLIST *sorted,
@@ -376,11 +376,16 @@ visit_service(const RC_DEPTREE *deptree,
 	RC_STRINGLIST *provided;
 	RC_STRING *p;
 	const char *svcname;
+	static int looped = 0;
+	svcname = getenv("RC_SVCNAME");
+
+	if(looped)
+		return looped;
 
 	/* Check if we have already visited this service or not */
 	TAILQ_FOREACH(type, visited, entries)
 		if (strcmp(type->value, depinfo->service) == 0)
-			return;
+			return 0;
 	/* Add ourselves as a visited service */
 	rc_stringlist_add(visited, depinfo->service);
 
@@ -390,6 +395,16 @@ visit_service(const RC_DEPTREE *deptree,
 			continue;
 
 		TAILQ_FOREACH(service, dt->services, entries) {
+
+			if (options&RC_DEP_CHECKLOOP)
+				/* Check for dependencies loop.
+				   See: https://bugs.gentoo.org/show_bug.cgi?id=391945
+				*/
+				if (!strcmp(svcname, service->value)) {
+					looped = 1;
+					return looped;
+				}
+
 			if (!(options & RC_DEP_TRACE) ||
 			    strcmp(type->value, "iprovide") == 0)
 			{
@@ -437,11 +452,12 @@ visit_service(const RC_DEPTREE *deptree,
 
 	/* We've visited everything we need, so add ourselves unless we
 	   are also the service calling us or we are provided by something */
-	svcname = getenv("RC_SVCNAME");
 	if (!svcname || strcmp(svcname, depinfo->service) != 0) {
 		if (!get_deptype(depinfo, "providedby"))
 			rc_stringlist_add(sorted, depinfo->service);
 	}
+
+	return looped;
 }
 
 RC_STRINGLIST *
@@ -478,6 +494,9 @@ rc_deptree_depends(const RC_DEPTREE *deptree,
 	RC_STRINGLIST *visited = rc_stringlist_new();
 	RC_DEPINFO *di;
 	const RC_STRING *service;
+	int looped = 0;
+
+	errno = 0;  /* 0 - on success; ELOOP - on dependencies loop */
 
 	bootlevel = getenv("RC_BOOTLEVEL");
 	if (!bootlevel)
@@ -487,11 +506,17 @@ rc_deptree_depends(const RC_DEPTREE *deptree,
 			errno = ENOENT;
 			continue;
 		}
-		if (types)
-			visit_service(deptree, types, sorted, visited,
-				      di, runlevel, options);
+		if (types) {
+			if (visit_service(deptree, types, sorted, visited,
+				         di, runlevel, options)) 
+				looped = 1;
+		}
 	}
 	rc_stringlist_free(visited);
+
+	if (looped)
+		errno = ELOOP;
+
 	return sorted;
 }
 librc_hidden_def(rc_deptree_depends)

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -305,13 +305,15 @@ const char *rc_sys_v2(void);
  * These options can change the services found by the rc_get_depinfo and
  * rc_get_depends functions. */
 /*! Trace provided services */
-#define RC_DEP_TRACE    (1<<0)
+#define RC_DEP_TRACE     (1<<0)
 /*! Only use services added to runlevels */
-#define RC_DEP_STRICT   (1<<1)
+#define RC_DEP_STRICT    (1<<1)
 /*! Runlevel is starting */
-#define RC_DEP_START    (1<<2)
+#define RC_DEP_START     (1<<2)
 /*! Runlevel is stopping */
-#define RC_DEP_STOP     (1<<3)
+#define RC_DEP_STOP      (1<<3)
+/*! Check for dependencies loop */
+#define RC_DEP_CHECKLOOP (1<<4)
 
 /*! @name Dependencies
  * We analyse each init script and cache the resultant dependency tree.

--- a/src/rc/runscript.c
+++ b/src/rc/runscript.c
@@ -690,9 +690,17 @@ svc_start_deps(void)
 	if (dry_run)
 		return;
 
-	/* Now wait for them to start */
+	/* Getting dependencies to start */
+
 	services = rc_deptree_depends(deptree, types_nua, applet_list,
-	    runlevel, depoptions);
+	    runlevel,
+	    depoptions|(rc_conf_yesno("rc_parallel")?RC_DEP_CHECKLOOP:0));
+
+	if (errno == ELOOP)
+		eerrorx("ERROR: %s failed to start. Dependencies loop.", applet);
+
+	/* Now wait for them to start */
+
 	/* We use tmplist to hold our scheduled by list */
 	tmplist = rc_stringlist_new();
 	TAILQ_FOREACH(svc, services, entries) {


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=391945

IMHO, this's much more dirty and hackish way than the early loop detector (https://github.com/OpenRC/openrc/pull/12). I even not sure in this code (in contrast of early loop detector). But this may be used in conjunction with that one to do not hang up on unsolvable loops (need-loop).
