### PR TITLE
Fix permission warning in status call.

### DIFF
--- a/sh/runscript.sh.in
+++ b/sh/runscript.sh.in
@@ -215,12 +215,14 @@ if yesno "${rc_verbose:-$RC_VERBOSE}"; then
 fi
 
 # Apply cgroups settings if defined
+if [ "$1" = "start" ] ; then
 if [ "$(command -v cgroup_add_service)" = "cgroup_add_service" ]; then
 	cgroup_add_service /sys/fs/cgroup/openrc
 	cgroup_add_service /sys/fs/cgroup/systemd/system
 fi
 [ "$(command -v cgroup_set_limits)" = "cgroup_set_limits" ] && \
 	cgroup_set_limits
+fi
 
 # Load our script
 sourcex "$RC_SERVICE"


### PR DESCRIPTION
Status call should not set limits as it requires root permissions,
also this is not safe, as current process may reach limitation.

X-GENTOO-BUG: 500364
X-GENTOO-BUG-URL: https://bugs.gentoo.org/show_bug.cgi?id=500364
