### PR TITLE
Add support for verbose "local" service runscript

### DIFF
--- a/init.d/local.in
+++ b/init.d/local.in
@@ -12,40 +12,83 @@ depend()
 
 start()
 {
-	einfo "Starting local"
+	ebegin "Starting local"
 
-	local file
-	for file in @SYSCONFDIR@/local.d/*.start ; do
-		[ -x "$file" ] && "$file"
+	local file has_errors retval
+	eindent
+	for file in @SYSCONFDIR@/local.d/*.start; do
+		if [ -x "${file}" ]; then
+			has_executables=1
+			vebegin "Executing \"${file}\""
+			"${file}" 2>&1 >/dev/null
+			retval=$?
+			if [ ${retval} -ne 0 ]; then
+				has_errors=1
+				ewend ${retval} "Execution of \"${file}\" failed."
+			else
+				vewend 0
+			fi
+		fi
 	done
+	eoutdent
 
 	if command -v local_start >/dev/null 2>&1; then
-		ewarn "@SYSCONFDIR@/conf.d/local should be removed."
+		ewarn "\"@SYSCONFDIR@/conf.d/local\" should be removed."
 		ewarn "Please move the code from the local_start function"
-		ewarn "to scripts with an .start extension"
-		ewarn "in @SYSCONFDIR@/local.d"
+		ewarn "to executable scripts with an .start extension"
+		ewarn "in \"@SYSCONFDIR@/local.d\""
 		local_start
 	fi
 
-	eend 0
+	if [ -z "${has_errors}" ]; then
+		eend 0
+	fi
+
+	# We have to end with a zero exit code, because a failed execution
+	# of an executable @SYSCONFDIR@/local.d/*.start file shouldn't result in
+	# marking the local service as failed. Otherwise we are unable to
+	# execute any executable @SYSCONFDIR@/local.d/*.stop file, because a failed
+	# marked service cannot be stopped (and the stop function would
+	# actually call the executable @SYSCONFDIR@/local.d/*.stop file(s)).
+	return 0
 }
 
 stop()
 {
-	einfo "Stopping local"
+	ebegin "Stopping local"
 
-	local file
+	local file has_errors retval
+	eindent
 	for file in @SYSCONFDIR@/local.d/*.stop; do
-		[ -x "$file" ] && "$file"
+		if [ -x "${file}" ]; then
+			has_executables=1
+			vebegin "Executing \"${file}\""
+			"${file}" 2>&1 >/dev/null
+			retval=$?
+			if [ ${retval} -ne 0 ]; then
+				has_errors=1
+				ewend ${retval} "Execution of \"${file}\" failed."
+			else
+				vewend 0
+			fi
+		fi
 	done
+	eoutdent
 
 	if command -v local_stop >/dev/null 2>&1; then
-		ewarn "@SYSCONFDIR@/conf.d/local should be removed."
+		ewarn "\"@SYSCONFDIR@/conf.d/local\" should be removed."
 		ewarn "Please move the code from the local_stop function"
-		ewarn "to scripts with an .stop extension"
-		ewarn "in @SYSCONFDIR@/local.d"
+		ewarn "to executable scripts with an .stop extension"
+		ewarn "in \"@SYSCONFDIR@/local.d\""
 		local_stop
 	fi
 
-	eend 0
+	if [ -z "${has_errors}" ]; then
+		eend 0
+	fi
+
+	# An executable @SYSCONFDIR@/local.d/*.stop file which failed with a
+	# non-zero exit status is not a reason to mark this service
+	# as failed, therefore we have to end with a zero exit code.
+	return 0
 }


### PR DESCRIPTION
With this patch, the "local" service runscript will be verbose like the
"sysctl" service when 'rc_verbose="yes"' is set.

Example output successful start:

```
 * Stopping local ...
 *   Executing "/etc/local.d/00will-stop.stop" ...                  [ ok ]
 * Starting local ...
 *   Executing "/etc/local.d/00will-start.start" ...                [ ok ]
 *   Executing "/etc/local.d/01 test.start" ...                     [ ok ]
```

Example output with failing executables:

```
 * Stopping local ...
 *   Executing "/etc/local.d/00will-stop.stop" ...                  [ ok ]
 *   Executing "/etc/local.d/will-fail.stop" ...
mount: can't find foo in /etc/fstab
 *   Execution of "/etc/local.d/will-fail.stop" failed.             [ !! ]
 * Starting local ...
 *   Executing "/etc/local.d/00will-start.start" ...                [ ok ]
 *   Executing "/etc/local.d/01 test.start" ...                     [ ok ]
 *   Executing "/etc/local.d/will-fail2.start" ...
mount: can't find bar in /etc/fstab
 *   Execution of "/etc/local.d/will-fail2.start" failed.           [ !! ]
 *   Executing "/etc/local.d/will-fail.start" ...
mount: can't find foo in /etc/fstab
 *   Execution of "/etc/local.d/will-fail.start" failed.            [ !! ]
```

X-Gentoo-Bug: 489274
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=489274
