### PR TITLE
Own make target "dist" created, which adds a ChangeLog to the release tarball

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -14,8 +14,18 @@ SNAP=		${_SNAP}
 SNAPDIR=	${DISTPREFIX}-${SNAP}
 SNAPFILE=	${SNAPDIR}.tar.bz2
 
-dist:
+gitdist:
 	git archive --prefix=${DISTPREFIX}/ ${GITREF} | bzip2 > ${DISTFILE}
+
+dist:
+	sh -c ' \
+	D=$$(mktemp -d) && \
+	_GITLOG_LIMIT=$$(date --utc --date="1 year ago" +%Y-%m-%d) && \
+	mkdir $${D}/${DISTPREFIX} && \
+	git checkout-index -f -a --prefix=$${D}/${DISTPREFIX}/ && \
+	git log --after="$${_GITLOG_LIMIT}" >$${D}/${DISTPREFIX}/ChangeLog && \
+	tar cjf ${DISTFILE} --owner=0 --group=0 --format=posix --mode=a+rX -C $$D ${DISTPREFIX} && \
+	rm -rf $$D '
 
 distcheck: dist
 	rm -rf ${DISTPREFIX}


### PR DESCRIPTION
The new dedicated make target "dist" will do the same like "git archive" but
includes a ChangeLog into the release tarball.

The ChangeLog is limited to 1 year from the current date. This is tunable.

"git archive" is still available through "gitdist" target.
