### PR TITLE
Fix off-by-one error in --test argument printout in start-stop-daemon.

### DIFF
--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -1075,7 +1075,7 @@ start_stop_daemon(int argc, char **argv)
 			exit (EXIT_SUCCESS);
 
 		einfon("Would start");
-		while (argc-- >= 0)
+		while (argc-- > 0)
 			printf(" %s", *argv++);
 		printf("\n");
 		eindent();


### PR DESCRIPTION
I think there was a bug in the test there - on my system it would run one too many times, and segfault when it walked off the end of the argv array.   This small patch should fix it.