### PR TITLE
Adjust compiler and linker option order to ensure locally built includes...

### DIFF
--- a/mk/depend.mk
+++ b/mk/depend.mk
@@ -6,7 +6,7 @@ IGNOREFILES+=	.depend
 
 .depend: ${SRCS}
 	rm -f .depend
-	${CC} ${CPPFLAGS} -MM ${SRCS} > .depend
+	${CC} ${LOCAL_CPPFLAGS} ${CPPFLAGS} -MM ${SRCS} > .depend
 
 depend: .depend extra_depend
 

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -21,10 +21,10 @@ _LIBS+=			${SHLIB_NAME}
 CLEANFILES+=		${OBJS} ${SOBJS} ${_LIBS} ${SHLIB_LINK}
 
 %.o: %.c
-	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@
+	${CC} ${LOCAL_CFLAGS} ${LOCAL_CPPFLAGS} ${CFLAGS} ${CPPFLAGS} -c $< -o $@
 
 %.So: %.c
-	${CC} ${PICFLAG} -DPIC ${CPPFLAGS} ${CFLAGS} -c $< -o $@
+	${CC} ${PICFLAG} -DPIC ${LOCAL_CFLAGS} ${LOCAL_CPPFLAGS} ${CPPFLAGS} ${CFLAGS} -c $< -o $@
 
 all: depend ${_LIBS}
 
@@ -40,7 +40,7 @@ ${SHLIB_NAME}:	${SOBJS}
 	@${ECHO} building shared library $@
 	@rm -f $@ ${SHLIB_LINK}
 	@ln -fs $@ ${SHLIB_LINK}
-	${CC} ${CFLAGS} ${LDFLAGS} -shared -Wl,-x \
+	${CC} ${LOCAL_CFLAGS} ${CFLAGS} ${LOCAL_LDFLAGS} ${LDFLAGS} -shared -Wl,-x \
 	-o $@ -Wl,-soname,${SONAME} \
 	${SOBJS} ${LDADD}
 

--- a/mk/prog.mk
+++ b/mk/prog.mk
@@ -1,4 +1,4 @@
-# rules to build a library
+# rules to build a program
 # based on FreeBSD's bsd.prog.mk
 
 # Copyright (c) 2008 Roy Marples <roy@marples.name>
@@ -25,10 +25,10 @@ CLEANFILES+=		${OBJS} ${PROG}
 all: depend ${PROG}
 
 %.o: %.c
-	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@
+	${CC} ${LOCAL_CFLAGS} ${LOCAL_CPPFLAGS} ${CFLAGS} ${CPPFLAGS} -c $< -o $@
 
 ${PROG}: ${SCRIPTS} ${OBJS}
-	${CC} ${CFLAGS} ${LDFLAGS} -o $@ ${OBJS} ${LDADD}
+	${CC} ${LOCAL_CFLAGS} ${LOCAL_LDFLAGS}  ${CFLAGS} ${LDFLAGS} -o $@ ${OBJS} ${LDADD}
 
 clean:
 	rm -f ${CLEANFILES}

--- a/src/libeinfo/Makefile
+++ b/src/libeinfo/Makefile
@@ -4,7 +4,7 @@ SRCS=			libeinfo.c
 INCS=			einfo.h
 VERSION_MAP=		einfo.map
 
-CPPFLAGS+=		-I../includes
+LOCAL_CPPFLAGS+=		-I../includes
 
 MK=			../../mk
 include ${MK}/lib.mk

--- a/src/librc/Makefile
+++ b/src/librc/Makefile
@@ -7,7 +7,7 @@ VERSION_MAP=	rc.map
 
 LDADD+=		${LIBKVM}
 
-CPPFLAGS+=	-I../includes
+LOCAL_CPPFLAGS+=	-I../includes
 
 MK=		../../mk
 include ${MK}/lib.mk

--- a/src/rc/Makefile
+++ b/src/rc/Makefile
@@ -35,8 +35,8 @@ RC_SBINLINKS=	mark_service_starting mark_service_started \
 ALL_LINKS=	${BINLINKS} ${SBINLINKS} ${RC_BINLINKS} ${RC_SBINLINKS}
 CLEANFILES+=	${ALL_LINKS}
 
-CPPFLAGS+=	-I../includes -I../librc -I../libeinfo
-LDFLAGS+=	-L../librc -L../libeinfo
+LOCAL_CPPFLAGS=-I../includes -I../librc -I../libeinfo
+LOCAL_LDFLAGS=-L../librc -L../libeinfo
 LDADD+=		-lutil -lrc -leinfo
 
 include ../../Makefile.inc


### PR DESCRIPTION
When testing the QNX port I was briefly stymied by a weird behaviour where it seemed like my new changes wouldn't actually affect the build until I ran make install.   It turned out that the installed headers and libraries were being preferentially chosen as the -I and -L options to reference the local build tree were at the end of the compiler/linker arguments.

This patch creates a new placeholder for such options at the beginning of the command line, thus allowing the local -I and -L options to be prioritized.