### PR TITLE
savecache: Fix incorrect error if cache folder is not already created

### DIFF
--- a/init.d/savecache.in
+++ b/init.d/savecache.in
@@ -13,7 +13,7 @@ start()
 			return 1
 		fi
 	fi
-	if ! checkpath -W "$RC_LIBEXECDIR"/cache; then
+	if [ -e "$RC_LIBEXECDIR"/cache ] && ! checkpath -W "$RC_LIBEXECDIR"/cache; then
 		ewarn "WARNING: ${RC_LIBEXECDIR}/cache is not writable!"
 		if ! yesno "${RC_GOINGDOWN}"; then
 			ewarn "Unable to save deptree cache"


### PR DESCRIPTION
checkpath -W can fail if the specified path doesn't actually exist yet.
In this case savecache script should attempt to create the path if it is
missing, however it is pre-empted by the checkpath call.  This patch adds
an explicit existence test before exectuing checkpath.