### PR TITLE
start-stop-daemon: Fix regression in argument printing for --test 

### DIFF
--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -919,10 +919,13 @@ start_stop_daemon(int argc, char **argv)
 			exec = name;
 		if (name && start)
 			*argv = name;
-	} else if (name)
+	} else if (name) {
 		*--argv = name;
-	else if (exec)
+		++argc;
+    } else if (exec) {
 		*--argv = exec;
+		++argc;
+	};
 
 	if (stop || sig != -1) {
 		if (sig == -1)


### PR DESCRIPTION
...when --name or --exec is specified

The previous fix to --test (PR #34) prevented reading one too many arguments when --exec -or --name was not specified, but created a regression where the last argument would not print if either of those arguments was specified.   This patch corrects the issue.