### PR TITLE
Remove the DEBUG_MEMORY macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ We don't support building a static OpenRC with PAM.
 
 You may need to use `PROGLDFLAGS=-Wl,-Bstatic` on glibc instead of just `-static`.
 
-If you debug memory under valgrind, add `-DDEBUG_MEMORY`
-to your `CPPFLAGS` so that all malloc memory should be freed at exit.
-
 If you are building OpenRC for a Gentoo Prefix installation, add `MKPREFIX=yes`.
 
 `PKG_PREFIX` should be set to where packages install to by default.

--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -404,6 +404,12 @@ librc_hidden_def(rc_config_value)
  * each rc_conf_value call */
 static RC_STRINGLIST *rc_conf = NULL;
 
+static void
+_free_rc_conf(void)
+{
+	rc_stringlist_free(rc_conf);
+}
+
 char *
 rc_conf_value(const char *setting)
 {
@@ -413,17 +419,13 @@ rc_conf_value(const char *setting)
 
 	if (! rc_conf) {
 		rc_conf = rc_config_load(RC_CONF);
-#ifdef DEBUG_MEMORY
 		atexit(_free_rc_conf);
-#endif
 
 		/* Support old configs. */
 		if (exists(RC_CONF_OLD)) {
 			old = rc_config_load(RC_CONF_OLD);
 			TAILQ_CONCAT(rc_conf, old, entries);
-#ifdef DEBUG_MEMORY
 			free(old);
-#endif
 		}
 
 		rc_conf = rc_config_directory(rc_conf);
@@ -443,11 +445,3 @@ rc_conf_value(const char *setting)
 	return rc_config_value(rc_conf, setting);
 }
 librc_hidden_def(rc_conf_value)
-
-#ifdef DEBUG_MEMORY
-static void
-_free_rc_conf(void)
-{
-	rc_stringlist_free(rc_conf);
-}
-#endif

--- a/src/rc/openrc-run.c
+++ b/src/rc/openrc-run.c
@@ -247,7 +247,6 @@ cleanup(void)
 
 	rc_plugin_unload();
 
-#ifdef DEBUG_MEMORY
 	rc_stringlist_free(deptypes_b);
 	rc_stringlist_free(deptypes_n);
 	rc_stringlist_free(deptypes_nw);
@@ -267,7 +266,6 @@ cleanup(void)
 	free(service);
 	free(prefix);
 	free(runlevel);
-#endif
 }
 
 /* Buffer and lock all output messages so that we get readable content */
@@ -1097,9 +1095,7 @@ service_plugable(void)
 			break;
 		}
 	}
-#ifdef DEBUG_MEMORY
 	free(list);
-#endif
 	return allow;
 }
 

--- a/src/rc/rc-misc.c
+++ b/src/rc/rc-misc.c
@@ -110,11 +110,9 @@ env_filter(void)
 			setenv(env->value, e + 1, 1);
 	}
 
-#ifdef DEBUG_MEMORY
 	rc_stringlist_free(env_list);
 	rc_stringlist_free(env_allow);
 	rc_stringlist_free(profile);
-#endif
 }
 
 void

--- a/src/rc/rc-service.c
+++ b/src/rc/rc-service.c
@@ -76,9 +76,7 @@ int main(int argc, char **argv)
 		case 'e':
 			service = rc_service_resolve(optarg);
 			opt = service ? EXIT_SUCCESS : EXIT_FAILURE;
-#ifdef DEBUG_MEMORY
 			free(service);
-#endif
 			return opt;
 			/* NOTREACHED */
 		case 'i':
@@ -97,9 +95,7 @@ int main(int argc, char **argv)
 			rc_stringlist_sort(&list);
 			TAILQ_FOREACH(s, list, entries)
 			    printf("%s\n", s->value);
-#ifdef DEBUG_MEMORY
 			rc_stringlist_free(list);
-#endif
 			return EXIT_SUCCESS;
 			/* NOTREACHED */
 		case 'r':
@@ -107,9 +103,7 @@ int main(int argc, char **argv)
 			if (service == NULL)
 				return EXIT_FAILURE;
 			printf("%s\n", service);
-#ifdef DEBUG_MEMORY
 			free(service);
-#endif
 			return EXIT_SUCCESS;
 			/* NOTREACHED */
 

--- a/src/rc/rc-status.c
+++ b/src/rc/rc-status.c
@@ -331,7 +331,6 @@ int main(int argc, char **argv)
 
 exit:
 	free(runlevel);
-#ifdef DEBUG_MEMORY
 	rc_stringlist_free(alist);
 	rc_stringlist_free(needsme);
 	rc_stringlist_free(sservices);
@@ -340,7 +339,6 @@ exit:
 	rc_stringlist_free(types);
 	rc_stringlist_free(levels);
 	rc_deptree_free(deptree);
-#endif
 
 	return retval;
 }

--- a/src/rc/rc.c
+++ b/src/rc/rc.c
@@ -86,6 +86,12 @@ const char *usagestring = ""					\
 #define DEVBOOT			"/dev/.rcboot"
 
 const char *applet = NULL;
+static RC_STRINGLIST *hotplugged_services;
+static RC_STRINGLIST *stop_services;
+static RC_STRINGLIST *start_services;
+static RC_STRINGLIST *types_nw;
+static RC_STRINGLIST *types_nwua;
+static RC_DEPTREE *deptree;
 static char *runlevel;
 static RC_HOOK hook_out;
 
@@ -127,10 +133,8 @@ clean_failed(void)
 static void
 cleanup(void)
 {
-#ifdef DEBUG_MEMORY
 	RC_PID *p1 = LIST_FIRST(&service_pids);
 	RC_PID *p2;
-#endif
 
 	if (!rc_in_logger && !rc_in_plugin &&
 	    applet && (strcmp(applet, "rc") == 0 || strcmp(applet, "openrc") == 0))
@@ -152,7 +156,6 @@ cleanup(void)
 		rc_logger_close();
 	}
 
-#ifdef DEBUG_MEMORY
 	while (p1) {
 		p2 = LIST_NEXT(p1, entries);
 		free(p1);
@@ -166,7 +169,6 @@ cleanup(void)
 	rc_stringlist_free(types_nwua);
 	rc_deptree_free(deptree);
 	free(runlevel);
-#endif
 }
 
 static char
@@ -735,12 +737,6 @@ int main(int argc, char **argv)
 	const char *bootlevel = NULL;
 	char *newlevel = NULL;
 	const char *systype = NULL;
-	static RC_STRINGLIST *hotplugged_services;
-	static RC_STRINGLIST *stop_services;
-	static RC_STRINGLIST *start_services;
-	static RC_STRINGLIST *types_nw;
-	static RC_STRINGLIST *types_nwua;
-	static RC_DEPTREE *deptree;
 	RC_STRINGLIST *deporder = NULL;
 	RC_STRINGLIST *tmplist;
 	RC_STRING *service;

--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -177,7 +177,6 @@ free_schedulelist(void)
 	TAILQ_INIT(&schedule);
 }
 
-#ifdef DEBUG_MEMORY
 static void
 cleanup(void)
 {
@@ -185,7 +184,6 @@ cleanup(void)
 	free(nav);
 	free_schedulelist();
 }
-#endif
 
 static int
 parse_signal(const char *sig)
@@ -688,9 +686,7 @@ int main(int argc, char **argv)
 
 	applet = basename_c(argv[0]);
 	TAILQ_INIT(&schedule);
-#ifdef DEBUG_MEMORY
 	atexit(cleanup);
-#endif
 
 	signal_setup(SIGINT, handle_signal);
 	signal_setup(SIGQUIT, handle_signal);


### PR DESCRIPTION
We should always free memory we allocate; I do not see a reason we
should do otherwise.