### PR TITLE
Fix tmpfiles processing

### DIFF
--- a/sh/tmpfiles.sh.in
+++ b/sh/tmpfiles.sh.in
@@ -245,7 +245,7 @@ PREFIX=
 FILE=
 fragments=
 # XXX: The harcoding of /usr/lib/ is an explicit choice by upstream
-tmpfiles_dirs='/usr/lib/tmpfiles.d/ /etc/tmpfiles.d/ /run/tmpfiles.d/'
+tmpfiles_dirs='/usr/lib/tmpfiles.d/ /run/tmpfiles.d/ /etc/tmpfiles.d/'
 tmpfiles_basenames=''
 tmpfiles_d=''
 # Build a list of sorted unique basenames


### PR DESCRIPTION
Tmpfiles.d processing had /run overriding /usr/lib and /etc, but this is
not correct. The correct order, from lowest to highest, for tmpfiles
processing is:

* /usr/lib/tmpfiles.d/*.conf
* /run/tmpfiles.d/*.conf
* /etc/tmpfiles.d

This means /run/tmpfiles.d/*.conf can override /etc/tmpfiles.d/*.conf,
but /etc/tmpfiles.d/*.conf can override both of them.