### PR TITLE
Fix script execution in the local service

### DIFF
--- a/init.d/local.in
+++ b/init.d/local.in
@@ -20,7 +20,7 @@ start()
 	for file in @SYSCONFDIR@/local.d/*.start; do
 		if [ -x "${file}" ]; then
 			vebegin "Executing \"${file}\""
-			"${file}" $redirect
+			eval "${file}" $redirect
 			retval=$?
 			if [ ${retval} -ne 0 ]; then
 				has_errors=1
@@ -59,7 +59,7 @@ stop()
 	for file in @SYSCONFDIR@/local.d/*.stop; do
 		if [ -x "${file}" ]; then
 			vebegin "Executing \"${file}\""
-			"${file}" $redirect
+			eval "${file}" $redirect
 			retval=$?
 			if [ ${retval} -ne 0 ]; then
 				has_errors=1


### PR DESCRIPTION
The local service should use eval when it executes scripts since it has
the redirection set up in a variable.

X-Gentoo-Bug: 545012
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=545012