### PR TITLE
Make sysctl on Linux respect rc_verbose setting

### DIFF
--- a/init.d/sysctl.Linux.in
+++ b/init.d/sysctl.Linux.in
@@ -10,7 +10,10 @@ depend()
 
 start()
 {
+	local quiet
+	yesno $rc_verbose || quiet=-q
+
 	ebegin "Configuring kernel parameters"
-	sysctl --system
+	sysctl ${quiet} --system
 	eend $? "Unable to configure some kernel parameters"
 }


### PR DESCRIPTION
We do not need to spam the console with variable settings by default.

X-Gentoo-Bug: 541922
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=541922