### PR TITLE
librc: Fix crash if service name same as runlevel

### DIFF
--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -101,7 +101,9 @@ ls_dir(const char *dir, int options)
 					continue;
 			}
 			if (options & LS_DIR) {
-				if (stat(d->d_name, &buf) == 0 &&
+				snprintf(file, sizeof(file), "%s/%s",
+				    dir, d->d_name);
+				if (stat(file, &buf) != 0 ||
 				    !S_ISDIR(buf.st_mode))
 					continue;
 			}


### PR DESCRIPTION
If a servive has the same name as the runlevel it is in, openrc will
crash on changing to such runlevel. It goes in a recursive madness and
eventually gets a SEGV while in snprintf (don't know why).

This fixes two errors:
1. ls_dir stats files not with full path -> stat always returns != 0
2. ls_dir adds files to list if stat failed

X-Gentoo-Bug: 537304
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=537304