### PR TITLE
Prototype path keyword for depend()

### DIFF
--- a/init.d/mount.in
+++ b/init.d/mount.in
@@ -103,8 +103,7 @@ generate()
 			case "$fsopts" in
 			*noauto*) ;;
 			*)
-				local name="${fs#/}"
-				name="$(echo $name | sed 's#/#.#g')"
+				local name="$(_mountpoint_to_mountname $fs)"
 				einfo ln -snf mount "${svcpath}/${name}"
 				rc=$?
 				[ $rc -ne 0 ] && break

--- a/sh/functions.sh.in
+++ b/sh/functions.sh.in
@@ -63,6 +63,11 @@ _sanitize_path()
 	echo "$path"
 }
 
+_mountpoint_to_mountname()
+{
+	echo ${*#/} | sed 's#/#.#g'
+}
+
 # Allow our scripts to support zsh
 if [ -n "$ZSH_VERSION" ]; then
 	emulate sh

--- a/sh/gendepends.sh.in
+++ b/sh/gendepends.sh.in
@@ -28,6 +28,19 @@ provide() {
 keyword() {
 	[ -n "$*" ] && echo "$RC_SVCNAME keyword $*" >&3
 }
+path() {
+    # Resolve each entry into an ineed line on a mountpoint
+	[ -n "$*" ] || return
+	for PATHNAME in *; do
+	    # We loop here because some systems (QNX) can have multiple fs's backing a mountpoint
+	    # The sed line chops off the
+	    df -P $PATHNAME | sed 1d | while read one two three four five six; do
+	        # borrowed from mount's generate: should go somewhere higher up as a function
+			local name="$(_mountpoint_to_mountname $six)"
+            [ -n "$name" ] && echo "$RC_SVCNAME ineed mount.$name" >&3
+        done
+    done # for PATHNAME
+}
 depend() {
 	:
 }

--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -78,6 +78,9 @@ provide() {
 keyword() {
 	[ -n "$*" ] && echo "keyword $*"
 }
+path() {
+	[ -n "$*" ] && echo "path $*"
+}
 
 # Describe the init script to the user
 describe()
@@ -217,7 +220,7 @@ for _cmd; do
 		break
 	fi
 done
- 
+
 # Load our script
 sourcex "$RC_SERVICE"
 


### PR DESCRIPTION
This adds a prototype 'path' keyword for depend() functions that will look up where the specified path is mounted and emit an appropriate mount.xxx dependency line.

Testing was minimal, but it seemed to work OK on my QNX system.

