### PR TITLE
openrc-run: Fix default behavior when rc_hotplug is defined

### DIFF
--- a/src/rc/openrc-run.c
+++ b/src/rc/openrc-run.c
@@ -1028,7 +1028,7 @@ static bool
 service_plugable(void)
 {
 	char *list, *p, *token;
-	bool allow = true, truefalse;
+	bool allow = false, truefalse;
 	char *match = rc_conf_value("rc_hotplug");
 
 	if (!match)


### PR DESCRIPTION
I have discussed this with @williamh and @Whissi already, and I think we decided the change in behavior was problematic. Regardless, I want to submit this as an official pull request so that it can be accepted or rejected more formally. The commit summary follows.

When rc_hotplug is undefined, service_pluggable always returns false.

When rc_hotplug is defined, service_pluggable previously would return
true unless an entry in rc_hotplug negated the behavior for a specific
service.

This change makes service_pluggable return false unless an entry in
rc_hotplug says otherwise.