### PR TITLE
openrc-run: Fix default behavior when rc_hotplug is defined

### DIFF
--- a/src/rc/openrc-run.c
+++ b/src/rc/openrc-run.c
@@ -1028,7 +1028,7 @@ static bool
 service_plugable(void)
 {
 	char *list, *p, *token;
-	bool allow = true, truefalse;
+	bool allow = false, truefalse;
 	char *match = rc_conf_value("rc_hotplug");
 
 	if (!match)
@@ -1047,6 +1047,9 @@ service_plugable(void)
 
 		if (fnmatch(token, applet, 0) == 0) {
 			allow = truefalse;
+			break;
+		} else if (!truefalse) {
+			allow = true;
 			break;
 		}
 	}


### PR DESCRIPTION
When rc_hotplug is undefined, service_plugable always returns false.

When rc_hotplug is defined, service_plugable previously would return
true unless an entry in rc_hotplug negated the behavior for a specific
service.

This change makes service_plugable return false unless an entry in
rc_hotplug says otherwise, and doesn't break the '!foo' case, which is
supposed to match all services except 'foo'.

Obsoletes #63

X-Gentoo-Bug: 554540
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=554540