### PR TITLE
Fix for s6-svc handling

### DIFF
--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -33,7 +33,7 @@ s6_stop()
  fi
 	s6_service_link="${RC_SVCDIR}/s6-scan/${s6_service_path##*/}"
 	ebegin "Stopping ${name:-$RC_SVCNAME}"
-	s6-svc -wDd -T ${s6_service_timeout_stop:-10000} "${s6_service_link}"
+	s6-svc -wD -d -T ${s6_service_timeout_stop:-10000} "${s6_service_link}"
 	set -- $(s6-svstat "${s6_service_link}")
 	[ "$1" = "down" ]
 	eend $? "Failed to stop $RC_SVCNAME"

--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -33,7 +33,7 @@ s6_stop()
  fi
 	s6_service_link="${RC_SVCDIR}/s6-scan/${s6_service_path##*/}"
 	ebegin "Stopping ${name:-$RC_SVCNAME}"
-	s6-svc -Dd -T ${s6_service_timeout_stop:-10000} "${s6_service_link}"
+	s6-svc -wDd -T ${s6_service_timeout_stop:-10000} "${s6_service_link}"
 	set -- $(s6-svstat "${s6_service_link}")
 	[ "$1" = "down" ]
 	eend $? "Failed to stop $RC_SVCNAME"


### PR DESCRIPTION
s6 v2.2.0.0 changed the readyness notification flags for s6-svc from -D/-U to -wd/-wD/-wu/-wU in order to support more granular change types. This change updates the s6 helper script with the correct syntax. In addition, it will cause s6-svc to wait until the service is down and (if applicable) any follow-on ./finish script has completed before returning instead of returning after the service has terminated but before ./finish has exited.