### PR TITLE
start-stop-daemon: Add SSD_IONICELEVEL

### DIFF
--- a/etc/rc.conf.in
+++ b/etc/rc.conf.in
@@ -117,6 +117,9 @@
 # Some daemons are started and stopped via start-stop-daemon.
 # We can set some things on a per service basis, like the nicelevel.
 #SSD_NICELEVEL="-19"
+# Or the ionice level. The format is class[:data] , just like the
+# --ionice start-stop-daemon parameter.
+#SSD_IONICELEVEL="2:2"
 
 # Pass ulimit parameters
 # If you are using bash in POSIX mode for your shell, note that the

--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -712,6 +712,17 @@ start_stop_daemon(int argc, char **argv)
 		if (sscanf(tmp, "%d", &nicelevel) != 1)
 			eerror("%s: invalid nice level `%s' (SSD_NICELEVEL)",
 			    applet, tmp);
+		if ((tmp = getenv("SSD_IONICELEVEL"))) {
+			int n = sscanf(tmp, "%d:%d", &ionicec, &ioniced);
+			if (n != 1 && n != 2)
+				eerror("%s: invalid ionice level `%s' (SSD_IONICELEVEL)",
+				    applet, tmp);
+			if (ionicec == 0)
+				ioniced = 0;
+			else if (ionicec == 3)
+				ioniced = 7;
+			ionicec <<= 13; /* class shift */
+		}
 
 	/* Get our user name and initial dir */
 	p = getenv("USER");
@@ -1211,7 +1222,8 @@ start_stop_daemon(int argc, char **argv)
 			if ((strncmp(env->value, "RC_", 3) == 0 &&
 				strncmp(env->value, "RC_SERVICE=", 10) != 0 &&
 				strncmp(env->value, "RC_SVCNAME=", 10) != 0) ||
-			    strncmp(env->value, "SSD_NICELEVEL=", 14) == 0)
+				strncmp(env->value, "SSD_NICELEVEL=", 14) == 0 ||
+				strncmp(env->value, "SSD_IONICELEVEL=", 16) == 0)
 			{
 				p = strchr(env->value, '=');
 				*p = '\0';


### PR DESCRIPTION
This is the disk io counterpart to SSD_NICELEVEL.

Resolves issue #68 .

Concerns with the code:

* Testing *indicates* that sscanf won't touch pointer arguments that don't have a corresponding match in the string, but the manpage is silent on the matter. OTOH, the code on line 746 does the same thing that I do in my code, so we're not in *more* danger than we were before.

* The ionicec and ioniced manipulation on line 720 is copied from code that handles parsing of the command-line ionice adjustment string, on line 746. If this now-duplicate code needs to be pulled out into a function, I'd be more than happy to make the required changes.