### PR TITLE
librc: sh:  respect alternative INITDIR

### DIFF
--- a/mk/scripts.mk
+++ b/mk/scripts.mk
@@ -19,7 +19,7 @@ _PKG_SED:=		$(shell ${_PKG_SED_SH})
 _LCL_SED_SH=		if test "${PREFIX}" = "${LOCAL_PREFIX}"; then echo "-e 's:@LOCAL_PREFIX@::g'"; else echo "-e 's:@LOCAL_PREFIX@:${LOCAL_PREFIX}:g'"; fi
 _LCL_SED:=		$(shell ${_LCL_SED_SH})
 
-SED_REPLACE=		-e 's:@SHELL@:${SH}:g' -e 's:@LIB@:${LIBNAME}:g' -e 's:@SYSCONFDIR@:${SYSCONFDIR}:g' -e 's:@LIBEXECDIR@:${LIBEXECDIR}:g' -e 's:@PREFIX@:${PREFIX}:g' -e 's:@BINDIR@:${BINDIR}:g' -e 's:@SBINDIR@:${SBINDIR}:g' ${_PKG_SED} ${_LCL_SED}
+SED_REPLACE=		-e 's:@SHELL@:${SH}:g' -e 's:@LIB@:${LIBNAME}:g' -e 's:@SYSCONFDIR@:${SYSCONFDIR}:g' -e 's:@LIBEXECDIR@:${LIBEXECDIR}:g' -e 's:@PREFIX@:${PREFIX}:g' -e 's:@BINDIR@:${BINDIR}:g' -e 's:@SBINDIR@:${SBINDIR}:g' -e 's:@INITDIR@:${INITDIR}:g' ${_PKG_SED} ${_LCL_SED}
 
 # Tweak our shell scripts
 %.sh: %.sh.in

--- a/sh/gendepends.sh.in
+++ b/sh/gendepends.sh.in
@@ -55,7 +55,7 @@ depend() {
 
 _done_dirs=
 for _dir in \
-@SYSCONFDIR@/init.d \
+@INITDIR@ \
 @PKG_PREFIX@/etc/init.d \
 @LOCAL_PREFIX@/etc/init.d
 do

--- a/src/librc/Makefile
+++ b/src/librc/Makefile
@@ -20,6 +20,8 @@ SED_CMD+=	-e 's:@SYSCONFDIR@:${SYSCONFDIR}:g'
 SED_CMD+=	-e 's:@LIBEXECDIR@:${LIBEXECDIR}:g'
 SED_CMD+=	-e 's:@BINDIR@:${BINDIR}:g'
 SED_CMD+=	-e 's:@SBINDIR@:${SBINDIR}:g'
+SED_CMD+=	-e 's:@INITDIR@:${INITDIR}:g'
+SED_CMD+=	-e 's:@CONFDIR@:${CONFDIR}:g'
 
 _PKG_PREFIX=	-e 's:.*@PKG_PREFIX@.*:\#undef RC_PKG_PREFIX:g'
 ifneq (${PKG_PREFIX},)

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -26,6 +26,8 @@ extern "C" {
 #define RC_SYSCONFDIR		"@SYSCONFDIR@"
 #define RC_LIBDIR               "@PREFIX@/@LIB@/rc"
 #define RC_LIBEXECDIR           "@LIBEXECDIR@"
+#define RC_INITDIR              "@INITDIR@"
+
 #if defined(PREFIX)
 #define RC_SVCDIR               RC_LIBEXECDIR "/init.d"
 #elif defined(__linux__) || (defined(__FreeBSD_kernel__) && \
@@ -35,7 +37,6 @@ extern "C" {
 #define RC_SVCDIR               RC_LIBEXECDIR "/init.d"
 #endif
 #define RC_RUNLEVELDIR          RC_SYSCONFDIR "/runlevels"
-#define RC_INITDIR              RC_SYSCONFDIR "/init.d"
 #define RC_CONFDIR              RC_SYSCONFDIR "/conf.d"
 #define RC_PLUGINDIR            RC_LIBDIR "/plugins"
 


### PR DESCRIPTION
Remove hard-coded directory name for INITDIR, which was partially
respected by the build system but was being ignored at runtime.

Note that I didn't go through and mess with any of the documentation
where 'init.d' was currently referenced as they didn't have any SED rules
similar to the compiled/generated code.  I can do that if necessary.

Tested with ``/etc/openrc.d`` under Linux.
