### PR TITLE
Fix typo in RC_UNAME check of modules-load

### DIFF
--- a/init.d/modules-load.in
+++ b/init.d/modules-load.in
@@ -54,7 +54,7 @@ load_modules()
 		ebegin "Loading module $x"
 		case "$RC_UNAME" in
 			FreeBSD) kldload "$x"; rc=$? ;;
-			linux) modprobe -q "$x"; rc=$? ;;
+			Linux) modprobe -q "$x"; rc=$? ;;
 			*) ;;
 		esac
 		eend $rc "Failed to load $x"


### PR DESCRIPTION
The $RC_UNAME "Linux" had been misspelled as "linux".
As a consequence, entries in e.g. /etc/modules-load.d failed to
load any module succesfully under Linux(!)