### PR TITLE
do_service: Initialize idx to 0

### DIFF
--- a/src/rc/do_service.c
+++ b/src/rc/do_service.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 	bool ok = false;
 	char *service;
 	char *exec;
-	int idx;
+	int idx = 0;
 	RC_SERVICE state, bit;
 
 	applet = basename_c(argv[0]);


### PR DESCRIPTION
If index is not explicitly specified for service_started_daemon, it will
look for daemons by random index.