### PR TITLE
sh/init.sh.Linux.in: skip /proc sanity test if md5sum is missing

### DIFF
--- a/sh/init.sh.Linux.in
+++ b/sh/init.sh.Linux.in
@@ -21,7 +21,7 @@ fi
 mountproc=true
 f=/proc/self/environ
 if [ -e $f ]; then
-	if [ "$(VAR=a md5sum $f)" = "$(VAR=b md5sum $f)" ]; then
+	if command -v md5sum > /dev/null && [ "$(VAR=a md5sum $f)" = "$(VAR=b md5sum $f)" ]; then
 		eerror "You have cruft in /proc that should be deleted"
 	else
 		einfo "/proc is already mounted"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/594534#c7
