### PR TITLE
init.d/loopback: drop scope on loopback

### DIFF
--- a/init.d/loopback.in
+++ b/init.d/loopback.in
@@ -21,8 +21,8 @@ start()
 	if [ "$RC_UNAME" = Linux ]; then
 		ebegin "Bringing up network interface lo"
 		if command -v ip > /dev/null 2>&1; then
-			ip addr add 127.0.0.1/8 dev lo brd + scope host
-			ip route add 127.0.0.0/8 dev lo scope host
+			ip addr add 127.0.0.1/8 dev lo brd +
+			ip route add 127.0.0.0/8 dev lo
 			ip link set lo up
 		else
 			ifconfig lo 127.0.0.1 netmask 255.0.0.0


### PR DESCRIPTION
Busybox does not support the 'scope' argument on 'ip address add' or 'ip
route add', this is documented in BUSYBOX.md, but is no longer actually
needed, as the kernel does get it right without manual specification,
and the ifconfig variant already relies on the kernel to get it right.

X-Gentoo-Bug: 487208
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=487208
Signed-off-by: Robin H. Johnson robbat2@gentoo.org
