### PR TITLE
sh/openrc-run.sh: expose default start/stop/status

### DIFF
--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -146,10 +146,9 @@ _status()
 	fi
 }
 
-# Template start / stop / status functions
 # These functions select the appropriate function to call from the
 # supervisor modules
-start()
+default_start()
 {
 	local func=ssd_start
 	case "$supervisor" in
@@ -163,7 +162,7 @@ start()
 	$func
 }
 
-stop()
+default_stop()
 {
 	local func=ssd_stop
 	case "$supervisor" in
@@ -177,7 +176,7 @@ stop()
 	$func
 }
 
-status()
+default_status()
 {
 	local func=ssd_status
 	case "$supervisor" in
@@ -191,6 +190,26 @@ status()
 	$func
 }
 
+# Template start / stop / status functions
+# package init scripts may override these, but the bodies are as minimal as
+# possible, so that the init scripts can creatively wrap default_*
+# functions.
+start()
+{
+	default_start
+}
+
+stop()
+{
+	default_stop
+}
+
+status()
+{
+	default_status
+}
+
+# Start debug output
 yesno $RC_DEBUG && set -x
 
 # Load configuration settings. First the global ones, then any


### PR DESCRIPTION
Supervisor setups break easily when start/stop/status functions are not
default.

Applications that write multiple PIDs to a pidfile (eg HAProxy as
described in bug 601540), can also benefit from being able to call the
default start/stop/status with modified environment variables.

Expose the default start/stop/status functions as
openrc_default_start/stop/status, and use them for the defaults
start/stop/status.

Trivial usage example:
```
  stop()
  {
    t=$(mktemp)
    for pid in $(cat $pidfile) ; do
      echo $pid >$t
      pidfile=$t openrc_default_stop
    done
    rm -f $t
  }
```

X-Gentoo-Bug: 601540
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>