### PR TITLE
Localmount shouldn't mount remote filesystems

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -24,7 +24,7 @@ start()
 	# Mount local filesystems in /etc/fstab.
 	local critical= types="noproc" x= no_netdev= rc=
 	for x in $net_fs_list $extra_net_fs_list; do
-		types="${types},no${x}"
+		types="${types},${x}"
 	done
 
 	if [ "$RC_UNAME" = Linux ]; then


### PR DESCRIPTION
The /etc/init.d/localmount script has a syntax error that causes it to
attempt to mount remote filesystems, causing the boot to fail. The
script appends a "no" to each remote filesystem type, but it should only
be append the "no" to the beginning of the list.  This patch fixes
localmount on FreeBSD 12.0.  A review of the mount(8) manpage on Ubuntu
12.04 suggests that this patch is correct for Linux, too.

Downstream bug:
https://github.com/trueos/trueos-core/issues/220