### PR TITLE
sh/init.sh.Linux.in: skip /proc test if no md5sum

### DIFF
--- a/sh/init.sh.Linux.in
+++ b/sh/init.sh.Linux.in
@@ -11,6 +11,16 @@ if [ -d "@SYSCONFDIR@/rc.conf.d" ]; then
 	done
 fi
 
+# check for md5sum, and probably /usr too
+if command -v md5sum >/dev/null; then
+	got_md5sum=true
+else
+	eerror "md5sum is missing, which suggests /usr is not mounted"
+	eerror "If you have separate /usr, it must be mounted by initramfs"
+	eerror "If not, you should check coreutils is installed correctly"
+	got_md5sum=false
+fi
+
 # By default VServer already has /proc mounted, but OpenVZ does not!
 # However, some of our users have an old proc image in /proc
 # NFC how they managed that, but the end result means we have to test if
@@ -21,9 +31,12 @@ fi
 mountproc=true
 f=/proc/self/environ
 if [ -e $f ]; then
-	if [ "$(VAR=a md5sum $f)" = "$(VAR=b md5sum $f)" ]; then
+	if $got_md5sum && [ "$(VAR=a md5sum $f)" = "$(VAR=b md5sum $f)" ]; then
 		eerror "You have cruft in /proc that should be deleted"
 	else
+		# If they don't have md5sum, this will fail in pretty ways if
+		# /proc isn't really mounted.  Oh well, their system is busted
+		# anyway, and they get to keep the pieces.
 		einfo "/proc is already mounted"
 		mountproc=false
 	fi


### PR DESCRIPTION
This will also warn users if md5sum is missing, which serves as a pretty
good indicator that /usr is not mounted.

Supercedes #102