### PR TITLE
start-stop-daemon: Initial support EnvironmentFiles

### DIFF
--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -111,6 +111,8 @@ Same as the
 option.
 .It Fl e , -env Ar VAR=VALUE
 Set the environment variable VAR to VALUE.
+.It Fl E , -envfile Ar FILE
+Set environment variables via a EnvironmentFile.
 .It Fl g , -group Ar group
 Start the daemon as in the group.
 .It Fl k , -umask Ar mode

--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -67,7 +67,7 @@ static struct pam_conv conv = { NULL, NULL};
 
 const char *applet = NULL;
 const char *extraopts = NULL;
-const char *getoptstring = "I:KN:PR:Sa:bc:d:e:g:ik:mn:op:s:tu:r:w:x:1:2:" \
+const char *getoptstring = "I:KN:PR:Sa:bc:d:e:E:g:ik:mn:op:s:tu:r:w:x:1:2:" \
 	getoptstring_COMMON;
 const struct option longopts[] = {
 	{ "ionice",       1, NULL, 'I'},
@@ -80,6 +80,7 @@ const struct option longopts[] = {
 	{ "chuid",        1, NULL, 'c'},
 	{ "chdir",        1, NULL, 'd'},
 	{ "env",          1, NULL, 'e'},
+	{ "envfile",      1, NULL, 'E'},
 	{ "umask",        1, NULL, 'k'},
 	{ "group",        1, NULL, 'g'},
 	{ "interpreted",  0, NULL, 'i'},
@@ -109,6 +110,7 @@ const char * const longopts_help[] = {
 	"deprecated, use --user",
 	"Change the PWD",
 	"Set an environment string",
+	"Read environment strings from a file",
 	"Set the umask for the daemon",
 	"Change the process group",
 	"Match process name by interpreter",
@@ -812,6 +814,10 @@ int main(int argc, char **argv)
 
 		case 'e': /* --env */
 			putenv(optarg);
+			break;
+
+		case 'E': /* --envfile */
+			putenvfile(optarg);
 			break;
 
 		case 'g':  /* --group <group>|<gid> */


### PR DESCRIPTION
This would enable services to read from a generic environment file besides conf.d/service.conf.

See also:
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=

Two smaller parts of the specification are not implemented yet:
* Support multiline variable definitions
* Strip whitespaces unless double quoted