### PR TITLE
sysfs: don't pull modules to sysinit runlevel

### DIFF
--- a/init.d/sysfs.in
+++ b/init.d/sysfs.in
@@ -15,7 +15,7 @@ sysfs_opts=nodev,noexec,nosuid
 
 depend()
 {
-	want modules
+	use modules
 	keyword -docker -lxc -prefix -systemd-nspawn -vserver
 }
 
@@ -105,7 +105,9 @@ mount_misc()
 		if [ ! -d /sys/firmware/efi/efivars ] &&
 			modprobe -q efivarfs; then
 			ewarn "The efivarfs module needs to be configured in " \
-				  "@SYSCONFDIR@/conf.d/modules or built in"
+				  "@SYSCONFDIR@/conf.d/modules (with " \
+				  "\"modules\" added to sysinit runlevel) or " \
+				  "built in"
 		fi
 		if [ -d /sys/firmware/efi/efivars ] &&
 			! mountinfo -q /sys/firmware/efi/efivars; then


### PR DESCRIPTION
Commit 73cdf10f1f51 ("Deprecate automatic loading of modules") introduced
"want modules" dependency for the "sysfs" service.

By default the "sysfs" service is installed in the "sysinit" runlevel, is
one of the very first services to start on boot (often it is the first one)
and it is always started before udev since udev depends on it.
The "modules" service on the other hand is supposed to start a bit later,
in the "boot" runlevel.

However, since that mentioned earlier commit the "modules" service will be
pulled in to the "sysinit" runlevel because a "want" dependency will do it
regardless in which runlevel this service is actually installed.
This breaks things like USB modem mode switching.

Change this dependency to an "use" which does not automatically pull in the
"modules" service into the "sysinit" runlevel and inform an user that he
needs to add it manually to this runlevel in case that he boots an EFI
Linux system AND efivarfs support wasn't built in into the kernel AND
efivarfs module wasn't loaded already by an initrd.