### PR TITLE
test/setup_env: ensure that eval_ecolors is available on the path.

### DIFF
--- a/test/setup_env.sh
+++ b/test/setup_env.sh
@@ -9,6 +9,10 @@ srcdir=${srcdir:-.}
 top_builddir=${top_builddir:-${top_srcdir}}
 builddir=${builddir:-${srcdir}}
 
+LD_LIBRARY_PATH=${top_builddir}/src/libeinfo:${top_builddir}/src/librc:${LD_LIBRARY_PATH}
+PATH=${top_builddir}/src/rc:${PATH}
+export LD_LIBRARY_PATH PATH
+
 if [ ! -f ${top_srcdir}/sh/functions.sh ] ; then
 	echo "functions.sh not yet created !?" 1>&2
 	exit 1
@@ -16,8 +20,4 @@ elif ! . ${top_srcdir}/sh/functions.sh; then
 	echo "Sourcing functions.sh failed !?" 1>&2
 	exit 1
 fi
-
-LD_LIBRARY_PATH=${top_builddir}/src/libeinfo:${top_builddir}/src/librc:${LD_LIBRARY_PATH}
-PATH=${top_builddir}/src/rc:${PATH}
-export LD_LIBRARY_PATH PATH
 


### PR DESCRIPTION
The test environment previously used the system default paths instead of installing the necessary $PATH environment
variable to make finding eval_ecolors work.

This closes Gentoo bug #374191.