### PR TITLE
Fix make install on FreeBSD: don't try to install /etc/init.d/modules twice

### DIFF
--- a/init.d/Makefile
+++ b/init.d/Makefile
@@ -19,7 +19,7 @@ SRCS-FreeBSD=	hostid.in modules.in moused.in newsyslog.in pf.in rarpd.in \
 		rc-enabled.in rpcbind.in savecore.in syslogd.in
 # These are FreeBSD specific
 SRCS-FreeBSD+=	adjkerntz.in devd.in dumpon.in encswap.in ipfw.in \
-		modules.in modules-load.in mixer.in nscd.in powerd.in syscons.in
+		modules-load.in mixer.in nscd.in powerd.in syscons.in
 
 SRCS-Linux=	agetty.in binfmt.in devfs.in dmesg.in hwclock.in consolefont.in \
 	keymaps.in killprocs.in modules.in modules-load.in mount-ro.in mtab.in \


### PR DESCRIPTION
Issue appeared for me during building Gentoo/FreeBSD system on Gentoo/Linux host.

It produces following output:
```
install -m 0755 bootmisc fsck hostname local localmount loopback netmount osclock root savecache swap swclock sysctl runsvdir urandom s6-svscan hostid modules mosed newsyslog pf rarpd rc-enabled rpcbind savecore syslogd adjkerntz devd dumpon encswap ipfw modules modules-load mixer nscd powerd syscons /usr/x86_64-gentoo-freebsd10.3/tmp/portage/sys-apps/openrc-0.24.2/image///etc/init.d/
/usr/bin/install: will not overwrite just created '/usr/x86_64-gentoo-freebsd10.3/tmp/portage/sys-apps/openrc-0.24.2/image///etc/init.d/modules' with 'modules'
```

Please note modules being mentioned twice in install parameters. Removing one of appearances fixes issue.