### PR TITLE
mk/cc.mk: make implicit function declarations fatal

### DIFF
--- a/mk/cc.mk
+++ b/mk/cc.mk
@@ -26,7 +26,8 @@ _CCFLAGS=	-Wall -Wextra -Wimplicit -Wshadow -Wformat=2 \
 		-Wnested-externs \
 		-Winline -Wwrite-strings -Wcast-align -Wcast-qual \
 		-Wpointer-arith \
-		-Wdeclaration-after-statement -Wsequence-point
+		-Wdeclaration-after-statement -Wsequence-point \
+		-Werror=implicit-function-declaration
 
 # We should be using -Wredundant-decls, but our library hidden proto stuff
 # gives loads of warnings. I don't fully understand it (the hidden proto,


### PR DESCRIPTION
When building openrc from git on uclibg-ng system
a lot of warnings suggest prototypes are missing
for various functions:

```
  start-stop-daemon.c:1197:21: warning: implicit declaration of function 'initgroups' [-Wimplicit-function-declaration]
   if (changeuser && initgroups(changeuser, gid))
                     ^
  start-stop-daemon.c:1197:3: warning: nested extern declaration of 'initgroups' [-Wnested-externs]
   if (changeuser && initgroups(changeuser, gid))
   ^
```

It means all arguments are defaulted to 'int'. It's a
problem for pointer arguments where truncation happens.

To avoid that truncation change forbids inplicit declarations.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>