### PR TITLE
rc-logger.c: fix crash on fclose(NULL)

### DIFF
--- a/src/rc/rc-logger.c
+++ b/src/rc/rc-logger.c
@@ -261,12 +261,12 @@ rc_logger_open(const char *level)
 						break;
 					}
 				}
+				fclose(log);
 			} else {
 				log_error = 1;
 				eerror("Error: fopen(%s) failed: %s", TMPLOG, strerror(errno));
 			}
 
-			fclose(log);
 			fclose(plog);
 		} else {
 			/*


### PR DESCRIPTION
Truncated crash looked like that:

```
Core was generated by `/sbin/openrc default'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  _IO_new_fclose (fp=0x0) at iofclose.c:53
```

rc_logger_open() has roughly the following code:

```
if ((plog = fopen(logfile, "ae"))) {
        if ((log = fopen(TMPLOG, "re"))) {
            ....
        }
        fclose(log);
        fclose(plog);
}
```

Note that `fclose(log)` is called unconditionally.

The change moves `fclose(log)` up to close file
only it was opened successfully.

Reported-by: Brian Evans <grknight@gentoo.org>
Tested-by: Brian Evans <grknight@gentoo.org>
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>