### PR TITLE
scripts/Makefile: respect SBINDIR with MKSYSVINIT

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -22,7 +22,7 @@ ifeq (${MKSYSVINIT},yes)
 	ln -sf	${DIR}/halt ${DESTDIR}/${SBINDIR}/halt
 	ln -sf	${DIR}/poweroff ${DESTDIR}/${SBINDIR}/poweroff
 	ln -sf	${DIR}/reboot ${DESTDIR}/${SBINDIR}/reboot
-	ln -sf	openrc-shutdown ${DESTDIR}/${SBINDIR}/shutdown
+	ln -sf	${DIR}/shutdown ${DESTDIR}/${SBINDIR}/shutdown
 	ln -sf	openrc-init ${DESTDIR}/${SBINDIR}/init
 endif
 endif

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -19,11 +19,11 @@ ifeq (${OS},Linux)
 	${INSTALL} -d ${DESTDIR}${SBINDIR}
 	ln -sf ../${DIR}/rc-sstat ${DESTDIR}/${SBINDIR}/rc-sstat
 ifeq (${MKSYSVINIT},yes)
-	ln -sf	../${DIR}/halt ${DESTDIR}/sbin/halt
-	ln -sf	../${DIR}/poweroff ${DESTDIR}/sbin/poweroff
-	ln -sf	../${DIR}/reboot ${DESTDIR}/sbin/reboot
-	ln -sf	../${DIR}/shutdown ${DESTDIR}/sbin/shutdown
-	ln -sf	openrc-init ${DESTDIR}/sbin/init
+	ln -sf	../${DIR}/halt ${DESTDIR}/${SBINDIR}/halt
+	ln -sf	../${DIR}/poweroff ${DESTDIR}/${SBINDIR}/poweroff
+	ln -sf	../${DIR}/reboot ${DESTDIR}/${SBINDIR}/reboot
+	ln -sf	../${DIR}/shutdown ${DESTDIR}/${SBINDIR}/shutdown
+	ln -sf	openrc-init ${DESTDIR}/${SBINDIR}/init
 endif
 endif
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -17,12 +17,12 @@ endif
 _installafter:
 ifeq (${OS},Linux)
 	${INSTALL} -d ${DESTDIR}${SBINDIR}
-	ln -sf ../${DIR}/rc-sstat ${DESTDIR}/${SBINDIR}/rc-sstat
+	ln -sf ${DIR}/rc-sstat ${DESTDIR}/${SBINDIR}/rc-sstat
 ifeq (${MKSYSVINIT},yes)
-	ln -sf	../${DIR}/halt ${DESTDIR}/${SBINDIR}/halt
-	ln -sf	../${DIR}/poweroff ${DESTDIR}/${SBINDIR}/poweroff
-	ln -sf	../${DIR}/reboot ${DESTDIR}/${SBINDIR}/reboot
-	ln -sf	../${DIR}/shutdown ${DESTDIR}/${SBINDIR}/shutdown
+	ln -sf	${DIR}/halt ${DESTDIR}/${SBINDIR}/halt
+	ln -sf	${DIR}/poweroff ${DESTDIR}/${SBINDIR}/poweroff
+	ln -sf	${DIR}/reboot ${DESTDIR}/${SBINDIR}/reboot
+	ln -sf	openrc-shutdown ${DESTDIR}/${SBINDIR}/shutdown
 	ln -sf	openrc-init ${DESTDIR}/${SBINDIR}/init
 endif
 endif


### PR DESCRIPTION
Use SBINDIR in the scripts Makefile and fix the symlinks if MKSYSVINIT=yes