### PR TITLE
add quiet option for agetty

### DIFF
--- a/conf.d/agetty
+++ b/conf.d/agetty
@@ -6,3 +6,6 @@
 
 # extra options to pass to agetty for this port
 #agetty_options=""
+
+# make agetty service quiet
+#quiet="YES"

--- a/init.d/agetty.in
+++ b/init.d/agetty.in
@@ -16,6 +16,7 @@ term_type="${term_type:-linux}"
 command=/sbin/agetty
 command_args_foreground="${agetty_options} ${port} ${baud} ${term_type}"
 pidfile="/run/${RC_SVCNAME}.pid"
+quiet="YES"
 
 depend() {
 	after local

--- a/init.d/agetty.in
+++ b/init.d/agetty.in
@@ -16,7 +16,7 @@ term_type="${term_type:-linux}"
 command=/sbin/agetty
 command_args_foreground="${agetty_options} ${port} ${baud} ${term_type}"
 pidfile="/run/${RC_SVCNAME}.pid"
-quiet="YES"
+quiet="${quiet:-YES}"
 
 depend() {
 	after local

--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -21,14 +21,20 @@ ssd_start()
 	fi
 
 	local _background=
-	ebegin "Starting ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		ebegin "Starting ${name:-$RC_SVCNAME}"
+	fi
 	if yesno "${command_background}"; then
 		if [ -z "${pidfile}" ]; then
-			eend 1 "command_background option used but no pidfile specified"
+			if [ ! "${quiet}" == "YES" ]; then
+				eend 1 "command_background option used but no pidfile specified"
+			fi
 			return 1
 		fi
 		if [ -n "${command_args_background}" ]; then
-			eend 1 "command_background used with command_args_background"
+			if [ ! "${quiet}" == "YES" ]; then
+				eend 1 "command_background used with command_args_background"
+			fi
 			return 1
 		fi
 		_background="--background --make-pidfile"
@@ -49,7 +55,11 @@ ssd_start()
 		${command_user+--user} $command_user \
 		$_background $start_stop_daemon_args \
 		-- $command_args $command_args_background
-	if eend $? "Failed to start ${name:-$RC_SVCNAME}"; then
+	rc=$?
+	if [ ! "${quiet}" == "YES" ]; then
+		eend $rc "Failed to start ${name:-$RC_SVCNAME}"
+	fi
+	if [ $rc ]; then
 		service_set_value "command" "${command}"
 		[ -n "${chroot}" ] && service_set_value "chroot" "${chroot}"
 		[ -n "${pidfile}" ] && service_set_value "pidfile" "${pidfile}"
@@ -77,7 +87,9 @@ ssd_stop()
 	procname="${startprocname:-$procname}"
 	[ -n "$command" -o -n "$procname" -o -n "$pidfile" ] || return 0
 	yesno "${command_progress}" && _progress=--progress
-	ebegin "Stopping ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		ebegin "Stopping ${name:-$RC_SVCNAME}"
+	fi
 	start-stop-daemon --stop \
 		${retry:+--retry} $retry \
 		${command:+--exec} $command \
@@ -86,7 +98,9 @@ ssd_stop()
 		${stopsig:+--signal} $stopsig \
 		${_progress}
 
-	eend $? "Failed to stop ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		eend $? "Failed to stop ${name:-$RC_SVCNAME}"
+	fi
 }
 
 ssd_status()

--- a/sh/supervise-daemon.sh
+++ b/sh/supervise-daemon.sh
@@ -18,7 +18,9 @@ supervise_start()
 		return 1
 	fi
 
-	ebegin "Starting ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		ebegin "Starting ${name:-$RC_SVCNAME}"
+	fi
 	# The eval call is necessary for cases like:
 	# command_args="this \"is a\" test"
 	# to work properly.
@@ -37,7 +39,9 @@ supervise_start()
 		[ -n "${chroot}" ] && service_set_value "chroot" "${chroot}"
 		[ -n "${pidfile}" ] && service_set_value "pidfile" "${pidfile}"
 	fi
-	eend $rc "failed to start ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		eend $rc "failed to start ${name:-$RC_SVCNAME}"
+	fi
 }
 
 supervise_stop()
@@ -47,12 +51,16 @@ supervise_stop()
 	chroot="${startchroot:-$chroot}"
 	pidfile="${startpidfile:-$pidfile}"
 	[ -n "$pidfile" ] || return 0
-	ebegin "Stopping ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		ebegin "Stopping ${name:-$RC_SVCNAME}"
+	fi
 	supervise-daemon --stop \
 		${pidfile:+--pidfile} $chroot$pidfile \
 		${stopsig:+--signal} $stopsig
 
-	eend $? "Failed to stop ${name:-$RC_SVCNAME}"
+	if [ ! "${quiet}" == "YES" ]; then
+		eend $? "Failed to stop ${name:-$RC_SVCNAME}"
+	fi
 }
 
 supervise_status()


### PR DESCRIPTION
This adds a quiet option that can be used to silence ebegin and eend for services. This fixes the display issue that happens under openrc-init using the agetty services: https://github.com/OpenRC/openrc/issues/121