### PR TITLE
support meson buildsystem

### DIFF
--- a/conf.d/meson.build
+++ b/conf.d/meson.build
@@ -1,0 +1,56 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+conf_d_conf = [
+  'bootmisc',
+  'fsck',
+  'hostname',
+  'localmount',
+  'netmount',
+  'swap',
+  'urandom',
+]
+
+if mk_net
+  conf_d_conf += ['network', 'staticroute']
+endif
+
+if os == 'Linux'
+  conf_d_conf += [
+    'agetty',
+    'consolefont',
+    'devfs',
+    'dmesg',
+    'hwclock',
+    'keymaps',
+    'killprocs',
+    'modules',
+    'mtab',
+    'net-online',
+  ]
+elif os == 'FreeBSD'
+  conf_d_conf += [
+    'ipfw',
+    'modules',
+    'moused',
+    'powerd',
+    'rarpd',
+    'savecore',
+    'syscons',
+  ]
+elif os == 'NetBSD'
+  conf_d_conf += [
+    'moused',
+    'rarpd',
+    'savecore',
+  ]
+endif
+
+install_data(conf_d_conf, install_dir: confdir)

--- a/etc/meson.build
+++ b/etc/meson.build
@@ -1,0 +1,41 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+etc_rc = configure_file(
+  input : 'rc.in',
+  output : 'rc',
+  configuration : substs,
+)
+
+
+etc_rc_shutdown = configure_file(
+  input : 'rc.shutdown.in',
+  output : 'rc.shutdown',
+  configuration : substs,
+)
+
+etc_conf = [
+  'rc.conf'
+]
+etc_bin = []
+
+if os == 'FreeBSD'
+  etc_bin += [etc_rc, etc_rc_shutdown, 'rc.devd']
+  etc_conf += ['devd.conf']
+elif os == 'Linux'
+  etc_bin += []
+  etc_conf += []
+elif os == 'NetBSD'
+  etc_bin += [etc_rc, etc_rc_shutdown]
+  etc_conf += []
+endif
+
+install_data(etc_bin, etc_conf, install_dir: sysconfdir)
+

--- a/init.d/meson.build
+++ b/init.d/meson.build
@@ -1,0 +1,112 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+init_d_srcs = [
+  'bootmisc',
+  'fsck',
+  'hostname',
+  'local',
+  'localmount',
+  'loopback',
+  'netmount',
+  'osclock',
+  'root',
+  'savecache',
+  'swap',
+  'swclock',
+  'sysctl',
+  'runsvdir',
+  'urandom',
+  's6-svscan',
+]
+
+# Are we installing our network scripts?
+if mk_net
+  init_d_srcs += [
+    'network',
+    'staticroute',
+  ]
+endif
+
+if os == 'FreeBSD'
+  # Generic BSD scripts
+  init_d_srcs += [
+    'hostid',
+    'modules',
+    'moused',
+    'newsyslog',
+    'pf',
+    'rarpd',
+    'rc-enabled',
+    'rpcbind',
+    'savecore',
+    'syslogd'
+  ]
+  # These are FreeBSD specific
+  init_d_srcs += [
+    'adjkerntz',
+    'devd',
+    'dumpon',
+    'encswap',
+    'ipfw modules-load',
+    'mixer',
+    'nscd',
+    'powerd',
+    'syscons'
+  ]
+elif os == 'Linux'
+  init_d_srcs += [
+    'agetty',
+    'binfmt',
+    'devfs',
+    'dmesg',
+    'hwclock',
+    'consolefont',
+    'keymaps',
+    'killprocs',
+    'modules',
+    'modules-load',
+    'mount-ro',
+    'mtab',
+    'numlock',
+    'procfs',
+    'net-online',
+    'sysfs',
+    'termencoding'
+  ]
+elif os == 'NetBSD'
+  # Generic BSD scripts
+  init_d_srcs += [
+    'hostid',
+    'moused',
+    'newsyslog',
+    'pf',
+    'rarpd',
+    'rc-enabled',
+    'rpcbind',
+    'savecore',
+    'syslogd'
+  ]
+  # These are NetBSD specific
+  init_d_srcs += [
+    'devdb',
+    'swap-blk',
+    'ttys',
+    'wscons'
+  ]
+endif
+
+foreach arg : init_d_srcs
+  configure_file(input: arg + '.in',
+                 output: arg,
+                 install : true,
+                 install_dir: initdir,
+                 configuration : substs)
+endforeach

--- a/local.d/meson.build
+++ b/local.d/meson.build
@@ -1,0 +1,11 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+install_data('README', install_dir : localdir)

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,0 +1,66 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+man3= [
+  'einfo',
+  'rc_config',
+  'rc_deptree',
+  'rc_find_pids',
+  'rc_plugin_hook',
+  'rc_runlevel',
+  'rc_service',
+  'rc_stringlist'
+]
+
+man8= [
+  'rc-service',
+  'rc-status',
+  'rc-update',
+  'openrc',
+  'openrc-run',
+  'start-stop-daemon',
+  'supervise-daemon'
+]
+
+if os == 'Linux'
+  man8 += [
+    'rc-sstat',
+    'openrc-init',
+    'openrc-shutdown'
+  ]
+endif
+
+foreach name : man3
+  man = name + '.3'
+  install_man(man, install_dir: join_paths(mandir, 'man3'))
+  sed_args = ['-e', 's/ ,//g', '-n', '-e', '/^\.Sh NAME$/,/\.Sh/  s/\.Nm //p']
+  manaliases = run_command('sed', sed_args, man).stdout().split()
+  foreach alias : manaliases
+    if alias != name
+      dst = join_paths(mandir, 'man3', alias + '.3.gz')
+      cmd = 'ln -sf @0@ $DESTDIR@1@'.format(man + '.gz', dst)
+      meson.add_install_script('sh', '-c', cmd)
+    endif
+  endforeach
+endforeach
+
+foreach name : man8
+  man = name + '.8'
+  install_man(man, install_dir: join_paths(mandir, 'man8'))
+  sed_args = ['-e', 's/ ,//g', '-n', '-e', '/^\.Sh NAME$/,/\.Sh/  s/\.Nm //p']
+  manaliases = run_command('sed', sed_args, man).stdout().split()
+  foreach alias : manaliases
+    if alias != name
+      dst = join_paths(mandir, 'man8', alias + '.8.gz')
+      cmd = 'ln -sf @0@ $DESTDIR@1@'.format(man + '.gz', dst)
+      meson.add_install_script('sh', '-c', cmd)
+    endif
+  endforeach
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,296 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+project('openrc', 'c',
+        license: 'Copyright (c) 2007-2017, the OpenRC authors',
+        version: '0.33.1',
+        meson_version: '>= 0.40',
+        default_options: [
+          'warning_level=1',
+          'prefix=/usr',
+          'libdir=lib',
+          'c_std=c99', # Default to using the C99 standard
+        ],
+       )
+
+mk_prefix = get_option('mk-prefix')
+rc_prefix = get_option('rc-prefix')
+rc_libname = get_option('rc-libname')
+rc_sysconfdir = get_option('rc-sysconfdir')
+rc_libexecdir = get_option('rc-libexecdir')
+rc_pkg_prefix = get_option('rc-pkg-prefix')
+rc_local_prefix = get_option('rc-local-prefix')
+rc_var_base = get_option('rc-var-prefix')
+
+mk_pkgconfig = get_option('pkgconfig')
+mk_net = get_option('net')
+mk_pam = get_option('pam')
+mk_selinux = get_option('selinux')
+mk_sysvinit = get_option('sysvinit')
+mk_termcap = get_option('termcap')
+mk_audit = get_option('audit')
+
+if not meson.is_cross_build()
+  # meson's system() function will return the operating system name ['linux',
+  # 'windows', 'darwin', 'cygwin', 'bsd'], but return bsd for all *BSD OSes, so
+  # using uname to detect os
+
+  # auto check os when do native build.
+  os = run_command('uname',  '-s').stdout().strip()
+  os = '-'.join(os.split('/'))
+else
+  # using os option's value when do cross build.
+  os = get_option('os')
+endif
+
+if rc_prefix == ''
+  uprefix = '/usr'
+  prefix = mk_prefix ? '/usr' : '/'
+else
+  uprefix = mk_prefix ? join_paths(re_prefix, 'usr') : re_prefix
+  prefix = mk_prefix ? join_paths(re_prefix, 'usr') : rc_prefix
+endif
+
+local_prefix = rc_local_prefix != '' ? rc_local_prefix : join_paths(uprefix, 'local')
+sysconfdir = rc_prefix != '' ? join_paths(re_prefix, 'etc') : '/etc'
+initdir = join_paths(sysconfdir, 'init.d')
+confdir = join_paths(sysconfdir, 'conf.d')
+localdir = join_paths(sysconfdir, 'local.d')
+sysctldir = join_paths(sysconfdir, 'sysctl.d')
+
+bindir = join_paths(prefix, 'bin')
+binmode = 'rwxr-xr-x' # 0755
+sbindir = join_paths(prefix, 'sbin')
+sbinmode = 'rwxr-xr-x' # 0755
+incdir = join_paths(prefix, 'include')
+incmode = 'r--r--r--' # '0444'
+
+if rc_libname != ''
+  libname = rc_libname
+else
+  libname = run_command('readlink', '/lib').stdout().strip()
+  if libname.contains('lib64')
+    libname = 'lib64'
+  else
+    libname = 'lib'
+  endif
+endif
+
+confdir = join_paths(rc_sysconfdir, 'conf.d')
+libdir = join_paths(uprefix, libname)
+libmode = 'r--r--r--' # '0444'
+shlibdir = join_paths(prefix, libname)
+libexecdir = rc_libexecdir != '' ? rc_libexecdir : join_paths(prefix, 'libexec', 'rc')
+manprefix = join_paths(uprefix, 'share')
+
+mandir = join_paths(manprefix, 'man')
+manmode = 'r--r--r--' # '0444'
+
+datadir = join_paths(uprefix, 'share', 'openrc')
+datamode = 'rw-r--r--' # '0644'
+
+docdir = join_paths(uprefix, 'share', 'doc')
+docmode = 'rw-r--r--' # '0644'
+confmode = 'rw-r--r--' # '0644'
+
+pkgconfiglibdir = join_paths(libdir, 'pkgconfig')
+
+
+cc = meson.get_compiler('c')
+
+# Try and use some good cc flags if we're building from git. We don't use
+# -pedantic as it will warn about our perfectly valid use of %m in our logger.
+# We should be using -Wredundant-decls, but our library hidden proto stuff gives
+# loads of warnings. I don't fully understand it (the hidden proto, not the
+# warning) so we just silence the warning.
+foreach arg : [
+  '-Wall',
+  '-Wextra',
+  '-Wimplicit',
+  '-Wshadow',
+  '-Wformat=2',
+  '-Wmissing-prototypes',
+  '-Wmissing-declarations',
+  '-Wmissing-noreturn',
+  '-Wmissing-format-attribute',
+  '-Wnested-externs',
+  '-Winline',
+  '-Wwrite-strings',
+  '-Wcast-align',
+  '-Wcast-qual',
+  '-Wpointer-arith',
+  '-Wdeclaration-after-statement',
+  '-Wsequence-point',
+  '-Werror=implicit-function-declaration',
+]
+  if cc.has_argument(arg)
+    add_project_arguments(arg, language : 'c')
+  endif
+endforeach
+
+library_deps = []
+common_compile_args = []
+
+mk_pam = get_option('pam')
+if mk_pam != 'false'
+  libpam = cc.find_library('pam', required : mk_pam == 'true')
+  libpam_misc = cc.find_library('pam_misc', required : mk_pam == 'true')
+  if libpam.found() and libpam_misc.found()
+    common_compile_args += ['-DHAVE_PAM']
+  endif
+endif
+
+mkselinux = false
+if mk_selinux != 'false'
+  libselinux = dependency('libselinux',
+                          version : '>= 2.1.9',
+                          required : mk_selinux == 'true')
+  if libselinux.found()
+    common_compile_args += ['-DHAVE_SELINUX']
+    mkselinux = true
+  endif
+endif
+
+mkaudit = false
+if mk_audit != 'false'
+  libaudit = dependency('audit', required : mk_audit == 'true')
+  if libaudit.found()
+    common_compile_args += ['-DHAVE_AUDIT']
+    mkaudit = true
+  endif
+endif
+
+mktermcap = false
+if mk_termcap == 'ncurses'
+  libncurses = dependency('ncurses', required : false)
+  if not libncurses.found()
+    libncurses = cc.find_library('ncurses', required : true)
+  endif
+  common_compile_args += ['-DHAVE_TERMCAP']
+  mktermcap = true
+elif mk_termcap == 'termcap'
+  libtermcap = cc.find_library('termcap', required : true)
+  common_compile_args += ['-DHAVE_TERMCAP']
+  mktermcap = true
+endif
+
+
+openrc_includes = include_directories('src/includes', 'src/libeinfo', 'src/librc')
+
+libutil = cc.find_library('util')
+library_deps += [libutil]
+
+substs = configuration_data()
+if os == 'Linux'
+  sfx = '.Linux.in'
+  pkg_prefix = rc_pkg_prefix != '' ? rc_pkg_prefix : '/usr'
+  common_compile_args += ['-D_DEFAULT_SOURCE', '-D_XOPEN_SOURCE=700']
+  add_project_link_arguments('-Wl,-Bdynamic', language : 'c')
+  libdl = cc.find_library('dl')
+  library_deps += [libdl]
+  substs.set('TERM', 'cons25')
+elif os == 'FreeBSD'
+  sfx = '.BSD.in'
+  pkg_prefix = rc_pkg_prefix != '' ? rc_pkg_prefix : '/usr/local'
+  common_compile_args += []
+  libkvm = cc.find_library('kvm')
+  library_deps += [libkvm]
+  substs.set('TERM', 'wsvt25')
+elif os == 'NetBSD'
+  sfx = '.BSD.in'
+  pkg_prefix = rc_pkg_prefix != '' ? rc_pkg_prefix : '/usr/pkg'
+  common_compile_args += []
+  libkvm = cc.find_library('kvm')
+  library_deps += [libkvm]
+  substs.set('TERM', 'wsvt25')
+elif os == 'DragonFly'
+  sfx = '.BSD.in'
+  pkg_prefix = rc_pkg_prefix != '' ? rc_pkg_prefix : '/usr/local'
+  common_compile_args += []
+  libkvm = cc.find_library('kvm')
+  library_deps += [libkvm]
+elif os == 'GNU-kFreeBSD'
+  sfx = '.GNU-kFreeBSD.in'
+  pkg_prefix = rc_pkg_prefix != '' ? rc_pkg_prefix : '/usr'
+  common_compile_args += ['-D_BSD_SOURCE', '-D_XOPEN_SOURCE=700']
+  add_project_link_arguments('-Wl,-Bdynamic', language : 'c')
+  libdl = cc.find_library('dl')
+  library_deps += [libdl]
+elif os == 'GNU'
+  sfx = '.GNU.in'
+  pkg_prefix = rc_pkg_prefix != '' ? rc_pkg_prefix : '/usr'
+  common_compile_args += ['-D_DEFAULT_SOURCE',
+                          '-D_XOPEN_SOURCE=700',
+                          '-DMAXPATHLEN=4096',
+                          '-DPATH_MAX=4096',
+                         ]
+  add_project_link_arguments('-Wl,-Bdynamic', language : 'c')
+  libdl = cc.find_library('dl')
+  library_deps += [libdl]
+else
+  error('Unsupported os: '+ os)
+endif
+
+substs.set('PREFIX', prefix)
+substs.set('LIB', libname)
+substs.set('SYSCONFDIR', sysconfdir)
+substs.set('LIBEXECDIR', libexecdir)
+substs.set('SBINDIR', sbindir)
+substs.set('BINDIR', bindir)
+substs.set('SYSCONFDIR', sysconfdir)
+substs.set('PKG_PREFIX', pkg_prefix)
+substs.set('LOCAL_PREFIX', local_prefix)
+substs.set('VARBASE', rc_var_base)
+substs.set('VERSION', meson.project_version())
+substs.set('SHELL', '/bin/sh')
+
+sed = find_program('sed')
+# grep = find_program('grep')
+# awk = find_program('awk')
+# stat = find_program('stat')
+git = find_program('git', required : false)
+
+if git.found()
+  git_head = run_command(
+    git,
+    ['--git-dir=@0@/.git'.format(meson.current_source_dir()),
+     'rev-parse', 'HEAD']).stdout().strip()
+  git_head_short = run_command(
+    git,
+    ['--git-dir=@0@/.git'.format(meson.current_source_dir()),
+     'rev-parse', '--short=7', 'HEAD']).stdout().strip()
+
+  run_target(
+    'git-snapshot',
+    command : ['git', 'archive',
+               '-o', '@0@/openrc-@1@.tar.gz'.format(meson.current_source_dir(),
+                                                    git_head_short),
+               '--prefix', 'openrc-@0@/'.format(git_head),
+               'HEAD'])
+endif
+
+subdirs = ['conf.d',
+           'etc',
+           'init.d',
+           'local.d',
+           'man',
+           'scripts',
+           'sh',
+           'src',
+           'support',
+           'sysctl.d',
+          ]
+foreach subdir : subdirs
+  subdir(subdir)
+endforeach
+
+if mk_pkgconfig
+  subdir('pkgconfig')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,55 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+option('mk-prefix', type : 'boolean', value : false,
+       description : '''Does /bin, /sbin are symlinks into /usr?''')
+option('rc-prefix', type : 'string',
+       description : '''Override the root prefix''')
+option('rc-libname', type : 'string',
+       description : '''lib directory name''')
+option('rc-sysconfdir', type : 'string',
+       description : '''Where sysconf files are installed''')
+option('rc-libexecdir', type : 'string',
+       description : '''Where libexec files are installed''')
+option('rc-pkg-prefix', type : 'string',
+       description : '''Where packages are installed''')
+option('rc-local-prefix', type : 'string',
+       description : '''Where user maintained packages are installed''')
+option('rc-var-prefix', type : 'string',
+       description : '''Where user maintained packages are installed''')
+option('pkgconfig', type : 'boolean', value : true,
+       description : 'Build pkgconfig or not')
+option('net', type : 'boolean', value : true,
+       description : 'Install network or not')
+option('pam', type : 'combo', choices : ['auto', 'true', 'false'],
+       value: 'false',
+       description : 'PAM support')
+option('selinux', type : 'combo', choices : ['auto', 'true', 'false'],
+       value: 'false',
+       description : 'SELinux support')
+option('audit', type : 'combo', choices : ['auto', 'true', 'false'],
+       value: 'false',
+       description : 'libaudit support')
+option('sysvinit', type : 'boolean', value : false,
+       description : 'support sysvinit or not')
+option('termcap', type : 'combo', choices : ['ncurses', 'termcap', 'false'],
+       value : 'false',
+       description : 'termcap')
+option('os', type : 'combo', choices : ['Linux',
+                                        'FreeBSD',
+                                        'NetBSD',
+                                        'DragonFly',
+                                        'GNU-kFreeBSD',
+                                        'GNU'
+                                       ],
+       value : 'Linux',
+       description : 'host OS')
+option('branding', type : 'string',
+       description : '''set branding''')

--- a/pkgconfig/meson.build
+++ b/pkgconfig/meson.build
@@ -1,0 +1,22 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+einfo_pc = configure_file(
+  input : 'einfo.pc.in',
+  output : 'einfo.pc',
+  configuration : substs)
+
+openrc_pc = configure_file(
+  input : 'openrc.pc.in',
+  output : 'openrc.pc',
+  configuration : substs)
+
+install_data(einfo_pc, openrc_pc,
+             install_dir : pkgconfiglibdir)

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,0 +1,47 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+scripts_install_dir = join_paths(libexecdir, 'bin')
+install_data('on_ac_power',
+             install_dir: scripts_install_dir,
+             install_mode: binmode,
+            )
+
+scripts_src = []
+
+if os == 'Linux'
+  scripts_src += ['rc-sstat']
+
+  if mk_sysvinit
+    scripts_src += ['halt',
+                    'poweroff',
+                    'reboot',
+                    'shutdown']
+  endif
+endif
+
+foreach arg : scripts_src
+  script_bin = configure_file(input: arg + '.in',
+                              output: arg,
+                              configuration : substs)
+  install_data(script_bin,
+               install_dir: scripts_install_dir,
+               install_mode: binmode,
+              )
+endforeach
+
+if os == 'Linux'
+  foreach name : scripts_src
+    src = join_paths(libexecdir, name)
+    dst = join_paths(sbindir, name)
+    cmd = 'mkdir -p $DESTDIR@0@; ln -sf @1@ $DESTDIR@2@'.format(sbindir, src, dst)
+    meson.add_install_script('sh', '-c', cmd)
+  endforeach
+endif

--- a/sh/meson.build
+++ b/sh/meson.build
@@ -1,0 +1,77 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+sh_install_dir = join_paths(libexecdir, 'sh')
+
+sh_incs = [
+  'rc-mount.sh',
+  # 'functions.sh',
+  # 'rc-functions.sh',
+  'runit.sh',
+  's6.sh',
+  'start-stop-daemon.sh',
+  'supervise-daemon.sh'
+]
+
+sh_bins = [
+  ['gendepends.sh.in', 'gendepends.sh'],
+  ['init.sh' + sfx, 'init.sh'],
+  ['openrc-run.sh.in', 'openrc-run.sh'],
+]
+
+if os == 'FreeBSD'
+# sh_bins += []
+elif os == 'Linux'
+  sh_bins += [
+    ['binfmt.sh.in', 'binfmt.sh'],
+    ['cgroup-release-agent.sh.in', 'cgroup-release-agent.sh'],
+    ['init-early.sh' + sfx, 'init-early.sh'],
+    ['migrate-to-run.sh.in', 'migrate-to-run.sh'],
+    ['rc-cgroup.sh.in', 'rc-cgroup.sh'],
+  ]
+elif os == 'NetBSD'
+  # sh_bins += []
+endif
+
+install_data(sh_incs,
+             install_dir: sh_install_dir,
+             install_mode: incmode,
+            )
+
+foreach arg : ['functions.sh', 'rc-functions.sh']
+  configure_file(input: arg + '.in',
+                 output: arg,
+                 configuration : substs,
+                 install_dir: sh_install_dir,
+                )
+endforeach
+
+
+
+foreach arg : sh_bins
+  sh_bin = configure_file(input: arg.get(0),
+                          output: arg.get(1),
+                          configuration : substs)
+  install_data(sh_bin,
+               install_dir: sh_install_dir,
+               install_mode: binmode,
+              )
+endforeach
+
+# TODO : update test scripts, make it can run in build directory
+sh_check_cmd = 'cd @0@; ./runtests.sh'.format(
+  meson.current_source_dir(),
+)
+
+run_target(
+  'sh-check',
+  command : ['sh', '-c', sh_check_cmd],
+)
+

--- a/src/libeinfo/meson.build
+++ b/src/libeinfo/meson.build
@@ -1,0 +1,27 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+SHLIB_MAJOR=1
+
+einfo_map_path = join_paths(meson.current_source_dir(), 'einfo.map')
+
+libeinfo = library(
+  'einfo',
+  'libeinfo.c',
+  soversion: SHLIB_MAJOR,
+  # version: '1.0.0',
+  include_directories : include_directories('../includes'),
+  link_args : ['-shared',
+               '-Wl,--version-script=' + einfo_map_path],
+  c_args: common_compile_args,
+  install : true,
+)
+
+install_headers('einfo.h')

--- a/src/librc/meson.build
+++ b/src/librc/meson.build
@@ -1,0 +1,34 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+shlib_major = 1
+
+configure_file(input : 'rc.h.in', output : 'rc.h',
+               install : true,
+               install_dir: get_option('includedir'),
+               configuration : substs)
+
+rc_map_path = join_paths(meson.current_source_dir(), 'rc.map')
+
+librc = library(
+  'rc',
+  'librc.c',
+  'librc-daemon.c',
+  'librc-depend.c',
+  'librc-misc.c',
+  'librc-stringlist.c',
+  soversion: shlib_major,
+  # version: '1.0.0',
+  include_directories : include_directories('../includes'),
+  link_args : ['-shared',
+               '-Wl,--version-script=' + rc_map_path],
+  c_args: common_compile_args,
+  install : true,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,37 @@
+# Copyright (c) 2007-2015 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+subdir('libeinfo')
+subdir('librc')
+subdir('rc')
+subdir('test')
+
+# TODO : update test scripts, make it can run in build directory
+# check_cmd = 'cp -afr @0@/test @1@; cd @2@; ./runtests.sh'.format(
+#   meson.current_source_dir(),
+#   meson.current_build_dir(),
+#   join_paths(meson.current_build_dir(), 'test'),
+# )
+
+# verbose_check_cmd = 'cp -afr @0@/test @1@; cd @2@; ./runtests.sh'.format(
+#   meson.current_source_dir(),
+#   meson.current_build_dir(),
+#   join_paths(meson.current_build_dir(), 'test'),
+# )
+
+# run_target(
+#   'check',
+#   command : ['sh', '-c', check_cmd],
+# )
+
+# run_target(
+#   'verbose-check',
+#   command : ['sh', '-c', verbose_check_cmd],
+# )

--- a/src/rc/meson.build
+++ b/src/rc/meson.build
@@ -1,0 +1,397 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+cdata = configuration_data()
+
+if git_head_short != ''
+  version = meson.project_version() + '.' + git_head_short
+else
+  version = meson.project_version()
+endif
+cdata.set_quoted('VERSION', version)
+branding = get_option('branding')
+if branding != ''
+  cdata.set_quoted('BRANDING', branding)
+endif
+
+configure_file(
+  output: 'version.h',
+  configuration: cdata,
+  install_dir: get_option('includedir'),
+)
+
+linkdir = libexecdir
+
+prog_link_args = []
+
+if prefix == '/'
+  # Some systems don't include /lib in their standard link path so we should embed
+  # it if different. This is currently hardcoded for NetBSD which has two dynamic
+  # linkers and we need to use the one in /libexec instead of /usr/libexec
+  if run_command('test', '-e', '/libexec/ld.elf_so').returncode() == 0
+    prog_link_args += ['-Wl,-dynamic-linker=/libexec/ld.elf_so']
+  endif
+endif
+
+rc_sources = [
+  '_usage.c',
+  'rc-misc.c',
+  'rc-schedules.c',
+  'rc-plugin.c',
+  'rc-wtmp.c',
+  'rc-logger.c'
+]
+
+if mkselinux
+  rc_sources += ['rc-selinux.c']
+endif
+
+rc_static = static_library(
+  'rc_static',
+  rc_sources,
+  include_directories : openrc_includes,
+  c_args: common_compile_args,
+  install : false,
+)
+
+checkpath = executable(
+  'checkpath',
+  'checkpath.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+kill_all = executable(
+  'kill_all',
+  'kill_all.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+foreach prog : [
+  'einfon',
+  'einfo',
+  'ewarnn',
+  'ewarn',
+  'eerrorn',
+  'eerror',
+  'ebegin',
+  'eend',
+  'ewend',
+  'eindent',
+  'eoutdent',
+  'esyslog',
+  'eval_ecolors',
+  'ewaitfile',
+  'veinfo',
+  'vewarn',
+  'vebegin',
+  'veend',
+  'vewend',
+  'veindent',
+  'veoutdent',
+]
+  executable(
+    prog,
+    'do_e.c',
+    c_args: common_compile_args,
+    include_directories : openrc_includes,
+    link_with: [rc_static, librc, libeinfo],
+    link_args: prog_link_args,
+    install : true,
+    install_dir: join_paths(linkdir, 'bin'),
+  )
+endforeach
+
+fstabinfo = executable(
+  'fstabinfo',
+  'fstabinfo.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+openrc_init = executable(
+  'openrc-init',
+  'openrc-init.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+is_newer_than = executable(
+  'is_newer_than',
+  'is_newer_than.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+is_older_than = executable(
+  'is_older_than',
+  'is_older_than.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+foreach prog : [
+  'mark_service_starting',
+  'mark_service_started',
+  'mark_service_stopping',
+  'mark_service_stopped',
+  'mark_service_inactive',
+  'mark_service_wasinactive',
+  'mark_service_hotplugged',
+  'mark_service_failed'
+]
+  executable(
+    prog,
+    'do_mark_service.c',
+    c_args: common_compile_args,
+    include_directories : openrc_includes,
+    link_with: [rc_static, librc, libeinfo],
+    link_args: prog_link_args,
+    install : true,
+    install_dir: join_paths(linkdir, 'sbin'),
+  )
+endforeach
+
+mountinfo = executable(
+  'mountinfo',
+  'mountinfo.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+openrc = executable(
+  'openrc',
+  'rc.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  dependencies: [library_deps],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+rc = executable(
+  'rc',
+  'rc.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  dependencies: [library_deps],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+openrc_shutdown = executable(
+  'openrc-shutdown',
+  'openrc-shutdown.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+openrc_run = executable(
+  'openrc-run',
+  'openrc-run.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  dependencies: [library_deps],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+runscript = executable(
+  'runscript',
+  'openrc-run.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  dependencies: [library_deps],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+rc_abort = executable(
+  'rc-abort',
+  'rc-abort.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: join_paths(linkdir, 'sbin'),
+)
+
+rc_depend = executable(
+  'rc-depend',
+  'rc-depend.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+rc_status = executable(
+  'rc-status',
+  'rc-status.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+rc_service = executable(
+  'rc-service',
+  'rc-service.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+rc_update = executable(
+  'rc-update',
+  'rc-update.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+start_stop_daemon = executable(
+  'start-stop-daemon',
+  'start-stop-daemon.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+supervise_daemon = executable(
+  'supervise-daemon',
+  'supervise-daemon.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: sbindir,
+)
+
+foreach prog : [
+  'service_get_value',
+  'service_set_value',
+  'get_options',
+  'save_options',
+]
+  executable(
+    prog,
+    'do_value.c',
+    c_args: common_compile_args,
+    include_directories : openrc_includes,
+    link_with: [rc_static, librc, libeinfo],
+    link_args: prog_link_args,
+    install : true,
+    install_dir: join_paths(linkdir, 'sbin'),
+  )
+endforeach
+
+foreach prog : [
+  'service_starting',
+  'service_started',
+  'service_stopping',
+  'service_stopped',
+  'service_inactive',
+  'service_wasinactive',
+  'service_hotplugged',
+  'service_started_daemon',
+  'service_crashed:',
+  'do_service.o',
+  'rc-misc.o',
+]
+  executable(
+    prog,
+    'do_service.c',
+    c_args: common_compile_args,
+    include_directories : openrc_includes,
+    link_with: [rc_static, librc, libeinfo],
+    link_args: prog_link_args,
+    install : true,
+    install_dir: join_paths(linkdir, 'sbin'),
+  )
+endforeach
+
+shell_var = executable(
+  'shell_var',
+  'shell_var.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: bindir,
+)
+
+swclock = executable(
+  'swclock',
+  'swclock.c',
+  c_args: common_compile_args,
+  include_directories : openrc_includes,
+  link_with: [rc_static, librc, libeinfo],
+  link_args: prog_link_args,
+  install : true,
+  install_dir: join_paths(linkdir, 'sbin'),
+)

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -1,0 +1,37 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+# TODO : update test scripts, make it can run in build directory
+check_cmd = 'cd @0@; ./runtests.sh'.format(
+  meson.current_source_dir(),
+)
+
+verbose_check_cmd = 'cd @0@; VERBOSE=yes ./runtests.sh'.format(
+  meson.current_source_dir(),
+)
+
+check_clean_cmd = 'cd @0@; rm -rf *.out tmp-*'.format(
+  meson.current_source_dir(),
+)
+
+run_target(
+  'check',
+  command : ['sh', '-c', check_cmd],
+)
+
+run_target(
+  'verbose-check',
+  command : ['sh', '-c', verbose_check_cmd],
+)
+
+run_target(
+  'check-clean',
+  command : ['sh', '-c', check_clean_cmd],
+)

--- a/support/deptree2dot/meson.build
+++ b/support/deptree2dot/meson.build
@@ -1,0 +1,22 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+support_deptree2dot_dir = join_paths(datadir, 'support', 'deptree2dot')
+support_deptree2dot_bin = 'deptree2dot'
+support_deptree2dot_inc = 'README.md'
+
+install_data(support_deptree2dot_bin,
+             install_dir: support_deptree2dot_dir,
+             install_mode: binmode,
+            )
+install_data(support_deptree2dot_inc,
+             install_dir: support_deptree2dot_dir,
+             install_mode: incmode,
+            )

--- a/support/init.d.examples/meson.build
+++ b/support/init.d.examples/meson.build
@@ -1,0 +1,44 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+support_deptree2dot_dir = join_paths(datadir, 'support', 'init.d.examples')
+
+support_deptree2dot_bins = [
+  'avahi-dnsconfd',
+  'avahid',
+  'dhcpcd',
+  'dbus',
+  'hald',
+  'named',
+  'ntpd',
+  'openvpn',
+  'polkitd',
+  'sshd',
+  'wpa_supplicant',
+]
+
+support_deptree2dot_inc = 'README.md'
+
+foreach arg : support_deptree2dot_bins
+  support_deptree2dot_bin = configure_file(
+    input: arg + '.in',
+    output: arg,
+    configuration : substs)
+  install_data(support_deptree2dot_bin,
+               install_dir: support_deptree2dot_dir,
+               install_mode: binmode,
+              )
+endforeach
+
+
+install_data(support_deptree2dot_inc,
+             install_dir: support_deptree2dot_dir,
+             install_mode: incmode,
+            )

--- a/support/meson.build
+++ b/support/meson.build
@@ -1,0 +1,17 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+subdir('deptree2dot')
+subdir('init.d.examples')
+subdir('openvpn')
+
+if os == 'Linux'
+  subdir('sysvinit')
+endif

--- a/support/openvpn/meson.build
+++ b/support/openvpn/meson.build
@@ -1,0 +1,26 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+openvpn_dir = join_paths(datadir, 'support', 'openvpn')
+
+openvpn_bins = ['down.sh', 'up.sh']
+openvpn_inc = 'README.md'
+
+install_data(openvpn_bins,
+             install_dir: openvpn_dir,
+             install_mode: binmode,
+            )
+
+install_data(openvpn_inc,
+             install_dir: openvpn_dir,
+             install_mode: incmode,
+            )
+
+

--- a/support/sysvinit/meson.build
+++ b/support/sysvinit/meson.build
@@ -1,0 +1,18 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+sysvinit_dir = join_paths(datadir, 'support', 'sysvinit')
+
+sysvinit_inc = ['inittab', 'README.md']
+
+install_data(sysvinit_inc,
+             install_dir: sysvinit_dir,
+             install_mode: incmode,
+            )

--- a/sysctl.d/meson.build
+++ b/sysctl.d/meson.build
@@ -1,0 +1,16 @@
+# Copyright (c) 2007-2017 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+sysctl_d_conf = 'README'
+
+install_data(sysctl_d_conf,
+             install_dir: sysctldir,
+             install_mode: confmode,
+            )


### PR DESCRIPTION
Openrc can build with meson, now

Usage:
```
pip3 install meson

wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
unzip -x ninja-linux.zip
chmod 755 ninja
cp ninja /usr/local/bin

meson builddir
ninja -C builddir
DESTDIR=out ninja -C builddir install
```

`ninja check` same as make check/test, but can't work, now, it need update shell scripts.

`ninja test` , can run all unit tests case,  see: http://mesonbuild.com/Unit-tests.html

These command can be use to developer to debug:
`meson test --wrap=valgrind testname`, `meson test --gdb testname`, `meson test --repeat=10`

you can generate coverage reports by giving Meson the command line flag -Db_coverage=true 
```
meson -Db_coverage=true builddir; 
ninja -C builddir test
```

cross compile:

just write a config file like below: e.g. crossbuild.ini
```
[binaries]
c = '/usr/bin/arm-linux-gnueabi-gcc'
cpp = '/usr/bin/arm-linux-gnueabi-g++'
ar = '/usr/bin/arm-linux-gnueabi-ar'
strip = '/usr/bin/arm-linux-gnueabi-strip'

[host_machine]
system = 'linux'
cpu_family = 'arm'
cpu = 'arm'
endian = 'little'
```

and run `meson builddir --cross-file crossbuild.ini`


