### PR TITLE
Gracefully handle unreadable /sys/class/net/dev/ nodes

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -44,10 +44,10 @@ start ()
 	ifcount=0
  	for dev in ${interfaces}; do
 		: $((ifcount += 1))
-		read x < /sys/class/net/$dev/carrier
-		[ $x -eq 1 ] && : $((carriers += 1))
-		read x < /sys/class/net/$dev/operstate
-		[ "$x" = up ] && : $((configured += 1))
+		read carrier < /sys/class/net/$dev/carrier 2> /dev/null
+		[ $carrier -eq 1 ] && : $((carriers += 1))
+		read operstate < /sys/class/net/$dev/operstate 2> /dev/null
+		[ "$operstate" = up ] && : $((configured += 1))
 	done
 	[ $configured -eq $ifcount ] && [ $carriers -ge 1 ] && break
 	sleep 1


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/629228

The fix mentioned in the gentoo bug report is not enough.
On the first failing try, the variable `x` would be assigned the
value `down` from the second check. On a second failing try,
the conditional `[ $x -eq 1 ]` will print an error:
`[: down: integer expression expected`