### PR TITLE
Update net-online.in

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -22,7 +22,7 @@ depend()
 get_interfaces()
 {
 	local ifname iftype
-	for ifname in /sys/class/net/*; do
+	for ifname in $(find /sys/class/net -type l); do
 		read iftype < ${ifname}/type
 		[ "$iftype" = "1" ] && printf "%s " ${ifname##*/}
 	done


### PR DESCRIPTION
In case the system is working with bonded devices, the funktion "get_interfaces" does not work, because in "/sys/class/net/" are not only symlinks.

see: --> https://elkano.org/blog/manage-interface-bondings-sysfs-interface/