### PR TITLE
Fix hardcoded sbin paths, improve file-access error messages

### DIFF
--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -23,6 +23,7 @@ extern "C" {
 #endif
 
 #define RC_PREFIX "@PREFIX@"
+#define RC_SBINDIR		"@SBINDIR@"
 #define RC_SYSCONFDIR		"@SYSCONFDIR@"
 #define RC_LIBDIR               "@PREFIX@/@LIB@/rc"
 #define RC_LIBEXECDIR           "@LIBEXECDIR@"

--- a/src/rc/checkpath.c
+++ b/src/rc/checkpath.c
@@ -103,7 +103,8 @@ static int do_check(char *path, uid_t uid, gid_t gid, mode_t mode,
 			fd = open(path, flags, mode);
 			umask(u);
 			if (fd == -1) {
-				eerror("%s: open: %s", applet, strerror(errno));
+				eerror("%s: open: %s: %s", applet, path,
+					strerror(errno));
 				return -1;
 			}
 			if (readfd != -1 && trunc)
@@ -118,14 +119,14 @@ static int do_check(char *path, uid_t uid, gid_t gid, mode_t mode,
 			r = mkdir(path, mode);
 			umask(u);
 			if (r == -1 && errno != EEXIST) {
-				eerror("%s: mkdir: %s", applet,
+				eerror("%s: mkdir: %s: %s", applet, path,
 				    strerror (errno));
 				return -1;
 			}
 			readfd = open(path, readflags);
 			if (readfd == -1) {
-				eerror("%s: unable to open directory: %s", applet,
-						strerror(errno));
+				eerror("%s: unable to open directory: %s: %s",
+					applet, path, strerror(errno));
 				return -1;
 			}
 		} else if (type == inode_fifo) {
@@ -136,14 +137,14 @@ static int do_check(char *path, uid_t uid, gid_t gid, mode_t mode,
 			r = mkfifo(path, mode);
 			umask(u);
 			if (r == -1 && errno != EEXIST) {
-				eerror("%s: mkfifo: %s", applet,
+				eerror("%s: mkfifo: %s: %s", applet, path,
 				    strerror (errno));
 				return -1;
 			}
 			readfd = open(path, readflags);
 			if (readfd == -1) {
-				eerror("%s: unable to open fifo: %s", applet,
-						strerror(errno));
+				eerror("%s: unable to open fifo: %s: %s",
+					applet, path, strerror(errno));
 				return -1;
 			}
 		}
@@ -178,7 +179,8 @@ static int do_check(char *path, uid_t uid, gid_t gid, mode_t mode,
 			}
 			einfo("%s: correcting mode", path);
 			if (fchmod(readfd, mode)) {
-				eerror("%s: chmod: %s", applet, strerror(errno));
+				eerror("%s: chmod: %s: %s",
+					applet, path, strerror(errno));
 				close(readfd);
 				return -1;
 			}
@@ -197,7 +199,8 @@ static int do_check(char *path, uid_t uid, gid_t gid, mode_t mode,
 			}
 			einfo("%s: correcting owner", path);
 			if (fchown(readfd, uid, gid)) {
-				eerror("%s: chown: %s", applet, strerror(errno));
+				eerror("%s: chown: %s: %s",
+					applet, path, strerror(errno));
 				close(readfd);
 				return -1;
 			}

--- a/src/rc/fstabinfo.c
+++ b/src/rc/fstabinfo.c
@@ -141,7 +141,7 @@ do_mount(struct ENT *ent, bool remount)
 		/* NOTREACHED */
 	case 0:
 		execvp(argv[0], argv);
-		eerror("%s: execv: %s", applet, strerror(errno));
+		eerror("%s: execv: %s: %s", applet, argv[0], strerror(errno));
 		_exit(EXIT_FAILURE);
 		/* NOTREACHED */
 	default:

--- a/src/rc/mountinfo.c
+++ b/src/rc/mountinfo.c
@@ -325,7 +325,7 @@ find_mounts(struct args *args)
 	RC_STRINGLIST *list;
 
 	if ((fp = fopen(procmounts, "r")) == NULL)
-		eerrorx("getmntinfo: %s", strerror(errno));
+		eerrorx("fopen: %s: %s", procmounts, strerror(errno));
 
 	list = rc_stringlist_new();
 

--- a/src/rc/openrc-init.c
+++ b/src/rc/openrc-init.c
@@ -56,7 +56,7 @@ static pid_t do_openrc(const char *runlevel)
 			sigprocmask(SIG_SETMASK, &signals, NULL);
 			printf("Starting %s runlevel\n", runlevel);
 			execl(OPENRC, OPENRC, runlevel, NULL);
-			perror("exec");
+			perror("exec: " OPENRC);
 			break;
 		default:
 			break;
@@ -189,14 +189,14 @@ int main(int argc, char **argv)
 		init(default_runlevel);
 
 	if (mkfifo(RC_INIT_FIFO, 0600) == -1 && errno != EEXIST)
-		perror("mkfifo");
+		perror("mkfifo: " RC_INIT_FIFO);
 
 	for (;;) {
 		/* This will block until a command is sent down the pipe... */
 		fifo = fopen(RC_INIT_FIFO, "r");
 		if (!fifo) {
 			if (errno != EINTR)
-				perror("fopen");
+				perror("fopen: " RC_INIT_FIFO);
 			continue;
 		}
 		count = fread(buf, 1, sizeof(buf) - 1, fifo);

--- a/src/rc/openrc-init.c
+++ b/src/rc/openrc-init.c
@@ -35,6 +35,8 @@
 #include "rc-wtmp.h"
 #include "version.h"
 
+#define OPENRC RC_SBINDIR "/openrc"
+
 static const char *rc_default_runlevel = "default";
 
 static pid_t do_openrc(const char *runlevel)
@@ -53,7 +55,7 @@ static pid_t do_openrc(const char *runlevel)
 			sigemptyset(&signals);
 			sigprocmask(SIG_SETMASK, &signals, NULL);
 			printf("Starting %s runlevel\n", runlevel);
-			execl("/sbin/openrc", "/sbin/openrc", runlevel, NULL);
+			execl(OPENRC, OPENRC, runlevel, NULL);
 			perror("exec");
 			break;
 		default:

--- a/src/rc/openrc-run.c
+++ b/src/rc/openrc-run.c
@@ -293,7 +293,8 @@ write_prefix(const char *buffer, size_t bytes, bool *prefixed)
 	if (lock_fd != -1) {
 		while (flock(lock_fd, LOCK_EX) != 0) {
 			if (errno != EINTR) {
-				ewarnv("flock() failed: %s", strerror(errno));
+				ewarnv("flock() `%s' failed: %s",
+					PREFIX_LOCK, strerror(errno));
 				break;
 			}
 		}
@@ -1135,7 +1136,8 @@ int main(int argc, char **argv)
 	 * to exist in the same directory as the master link.
 	 * Also, the master link as to be a real file in the init dir. */
 	if (!realpath(argv[1], path)) {
-		fprintf(stderr, "realpath: %s\n", strerror(errno));
+		fprintf(stderr, "realpath: %s: %s\n",
+			argv[1], strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 	memset(lnk, 0, sizeof(lnk));

--- a/src/rc/openrc-shutdown.c
+++ b/src/rc/openrc-shutdown.c
@@ -89,7 +89,7 @@ static void send_cmd(const char *cmd)
 		log_wtmp("shutdown", "~~", 0, RUN_LVL, "~~");
 	fifo = fopen(RC_INIT_FIFO, "w");
 	if (!fifo) {
-		perror("fopen");
+		perror("fopen: " RC_INIT_FIFO);
 		return;
 	}
 

--- a/src/rc/rc-misc.c
+++ b/src/rc/rc-misc.c
@@ -240,7 +240,7 @@ svc_lock(const char *applet)
 	if (fd == -1)
 		return -1;
 	if (flock(fd, LOCK_EX | LOCK_NB) == -1) {
-		eerror("Call to flock failed: %s", strerror(errno));
+		eerror("Call to flock(%s) failed: %s", file, strerror(errno));
 		close(fd);
 		return -1;
 	}

--- a/src/rc/rc-selinux.c
+++ b/src/rc/rc-selinux.c
@@ -402,11 +402,11 @@ void selinux_setup(char **argv)
 	 */
 	if (!access("/usr/sbin/open_init_pty", X_OK)) {
 		if (execvp("/usr/sbin/open_init_pty", argv)) {
-			perror("execvp");
+			perror("execvp: /usr/sbin/open_init_pty");
 			exit(-1);
 		}
 	} else if (execvp(argv[1], argv + 1)) {
-		perror("execvp");
+		fprintf(stderr, "execvp: %s: %s\n", argv[1], strerror(errno));
 		exit(-1);
 	}
 

--- a/src/rc/rc-service.c
+++ b/src/rc/rc-service.c
@@ -135,6 +135,6 @@ int main(int argc, char **argv)
 		return 0;
 	*argv = service;
 	execv(*argv, argv);
-	eerrorx("%s: %s", applet, strerror(errno));
+	eerrorx("%s: execv %s: %s", applet, *argv, strerror(errno));
 	/* NOTREACHED */
 }

--- a/src/rc/rc.c
+++ b/src/rc/rc.c
@@ -816,7 +816,8 @@ int main(int argc, char **argv)
 			argv += optind - 1;
 			*argv = newlevel;
 			execv(*argv, argv);
-			eerrorx("%s: %s", applet, strerror(errno));
+			eerrorx("%s: exec %s: %s",
+				applet, *argv, strerror(errno));
 			/* NOTREACHED */
 		case 'S':
 			systype = rc_sys();

--- a/src/rc/rc.c
+++ b/src/rc/rc.c
@@ -78,8 +78,9 @@ const char *usagestring = ""					\
 #define INITSH                  RC_LIBEXECDIR "/sh/init.sh"
 #define INITEARLYSH             RC_LIBEXECDIR "/sh/init-early.sh"
 
-#define SHUTDOWN                "/sbin/shutdown"
-#define SULOGIN                 "/sbin/sulogin"
+#define SHUTDOWN                RC_SBINDIR "/shutdown"
+#define SULOGIN                 RC_SBINDIR "/sulogin"
+#define HALT                    RC_SBINDIR "/halt"
 
 #define INTERACTIVE             RC_SVCDIR "/interactive"
 
@@ -288,8 +289,8 @@ open_shell(void)
 	/* VSERVER systems cannot really drop to shells */
 	if (sys && strcmp(sys, RC_SYS_VSERVER) == 0)
 	{
-		execl("/sbin/halt", "/sbin/halt", "-f", (char *) NULL);
-		eerrorx("%s: unable to exec `/sbin/halt': %s",
+		execl(HALT, HALT, "-f", (char *) NULL);
+		eerrorx("%s: unable to exec `" HALT "': %s",
 		    applet, strerror(errno));
 	}
 #endif

--- a/src/rc/swclock.c
+++ b/src/rc/swclock.c
@@ -80,11 +80,13 @@ int main(int argc, char **argv)
 		if (stat(file, &sb) == -1) {
 			opt = open(file, O_WRONLY | O_CREAT, 0644);
 			if (opt == -1)
-				eerrorx("swclock: open: %s", strerror(errno));
+				eerrorx("swclock: open: %s: %s",
+					file, strerror(errno));
 			close(opt);
 		} else
 			if (utime(file, NULL) == -1)
-				eerrorx("swclock: utime: %s", strerror(errno));
+				eerrorx("swclock: utime: %s: %s",
+					file, strerror(errno));
 		return 0;
 	}
 


### PR DESCRIPTION
A little bit of background: I was fiddling around with OpenRC on custom, cross compiled system that
doesn't have a /sbin directory. Setting SBINDIR=/bin compiled fine and installed everything to /bin.

However, I discovered that there were a few hard coded "/sbin/<foo>" paths in the code. This is what
the first commit tries to fix.

The reason I had to dig into the source code in the first place was because "exec: no such file or directory" wasn't exactly helpful in trying to find the cause of the problem (more precisely, such
an error message is utterly meaningless). I could have found the problem much faster if the program had simply told me that that it was trying to access something in /sbin. This is what the second
commit tries to fix.