### PR TITLE
helpers.h: xasprintf function, replace ... with ap_list ap, init vars

### DIFF
--- a/src/includes/helpers.h
+++ b/src/includes/helpers.h
@@ -132,12 +132,11 @@ _unused static bool existss(const char *pathname)
  * functions to handle memory allocation.
  * this function was originally written by Mike Frysinger.
  */
-_unused static int xasprintf(char **strp, const char *fmt, ...)
+_unused static int xasprintf(char **strp, const char *fmt, va_list ap)
 {
-	va_list ap;
-	int len;
-	int memlen;
-	char *ret;
+	int len = 0;
+	int memlen = 0;
+	char *ret = NULL;
 
 	/*
 	 * Start with a buffer size that should cover the vast majority of uses


### PR DESCRIPTION
Minor changes, feel free to drop var init stuff if you want. The other replacement is per the following.

MISRA C:2004, 16.1 - Functions shall not be defined with a variable number of arguments.
CERT, DCL50-CPP. - Do not define a C-style variadic function