### PR TITLE
check whether /sys/fs/cgroup is a mountpoint

### DIFF
--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -259,10 +259,13 @@ for _cmd; do
 			ulimit ${rc_ulimit:-$RC_ULIMIT}
 		# Apply cgroups settings if defined
 		if [ "$(command -v cgroup_add_service)" = "cgroup_add_service" ]
-		then
-			if [ -d /sys/fs/cgroup -a ! -w /sys/fs/cgroup ]; then
-				eerror "No permission to apply cgroup settings"
-				break
+		then    
+			if grep -qs /sys/fs/cgroup /proc/1/mountinfo > /dev/null
+			then
+				if [ -d /sys/fs/cgroup -a ! -w /sys/fs/cgroup ]; then
+					eerror "No permission to apply cgroup settings"
+					break
+				fi
 			fi
 			cgroup_add_service
 		fi


### PR DESCRIPTION
The current check only tries to detect whether /sys/fs/cgroup exists and
whether it is writable or not. But when the init system doesn't mount
cgroups then /sys/fs/cgroup will just be an empty directory. When paired
with unprivileged containers that mount sysfs this will cause misleading
errors to be printed since /sys/fs/cgroup will be owned by user
nobody:nogroup in this case. Independent of this specific problem this
check will also be misleading when the /sys/fs/cgroup exists and is in
fact writable by the init system but isn't actually a mountpoint.