### PR TITLE
swap should always be started after root, otherwise if a swap file is…

### DIFF
--- a/init.d/swap.in
+++ b/init.d/swap.in
@@ -11,7 +11,7 @@
 
 depend()
 {
-	after clock
+	after clock root
 	before localmount
 	keyword -docker -jail -lxc -openvz -prefix -systemd-nspawn -vserver
 }


### PR DESCRIPTION
… being used, and swap is started before root (I had this issue with rc_parallel="YES"), swapon may fail because of a read-only filesystem.