### PR TITLE
librc: fix realpath() return value check

### DIFF
--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -1042,7 +1042,6 @@ rc_service_add(const char *runlevel, const char *service)
 	char *init;
 	char file[PATH_MAX];
 	char path[MAXPATHLEN] = { '\0' };
-	char *p = NULL;
 	char binit[PATH_MAX];
 	char *i;
 
@@ -1063,8 +1062,7 @@ rc_service_add(const char *runlevel, const char *service)
 	/* We need to ensure that only things in /etc/init.d are added
 	 * to the boot runlevel */
 	if (strcmp(runlevel, RC_LEVEL_BOOT) == 0) {
-		p = realpath(dirname(init), path);
-		if (!*p) {
+		if (realpath(dirname(init), path) == NULL) {
 			free(init);
 			return false;
 		}


### PR DESCRIPTION
The return value of `realpath()` is checked by dereference, although it returns `NULL` if there is an error. This CL checks for a `NULL` return value instead of dereferencing the pointer.