### PR TITLE
hwclock: exit early if no rtc device is found

### DIFF
--- a/init.d/hwclock.in
+++ b/init.d/hwclock.in
@@ -97,7 +97,6 @@ start()
 		return 0
 	fi
 
-	ebegin "Setting system clock using the hardware clock [$utc]"
 	if [ -e /proc/modules ]; then
 		if ! rtc_exists; then
 			for x in rtc-cmos rtc genrtc; do
@@ -108,6 +107,10 @@ start()
 					"${RC_SERVICE%/*/*}/conf.d/modules or built in."
 		fi
 	fi
+
+	rtc_exists || return 0
+
+	ebegin "Setting system clock using the hardware clock [$utc]"
 
 	# Always set the kernel's time zone.
 	_hwclock --systz $utc_cmd $(get_noadjfile) $clock_args
@@ -138,6 +141,8 @@ stop()
 	setupopts
 
 	[ -z "$utc_cmd" ] && return 0
+
+	rtc_exists || return 0
 
 	ebegin "Setting hardware clock using the system clock" "[$utc]"
 


### PR DESCRIPTION
When using a rpi without rtc I always see this error:

hwclock: Cannot access the Hardware Clock via any known method.
hwclock: Use the --verbose option to see the details of our search for an access method.
