### PR TITLE
rc-status: prevent memory corruption by freeing uninitialized pointer

### DIFF
--- a/src/rc/rc-status.c
+++ b/src/rc/rc-status.c
@@ -87,7 +87,7 @@ static char *get_uptime(const char *service)
 	time_t diff_hours = (time_t) 0;
 	time_t diff_mins = (time_t) 0;
 	time_t diff_secs = (time_t) 0;
-	char *uptime;
+	char *uptime = NULL;
 
 	if (state & RC_SERVICE_STARTED) {
 		start_count = rc_service_value_get(service, "start_count");


### PR DESCRIPTION
After emerging 0.38 I reported a heap corruption via private email. I got bored so I dove in and found:

> (gdb) s
print_service (service=<optimized out>) at rc-status.c:162
162					free(uptime);
(gdb) s
free(): invalid pointer
>Program received signal SIGABRT, Aborted.
0x00007ffff722646b in raise () from /lib64/libc.so.6

As it turns out get_uptime() does not initialize its return value and returns stack garbage,
leading to heap corruption or other funny things down the line (depending on compiler,
optimization level etc.). With this fix rc-status works properly.
