### PR TITLE
librc-misc: remove leftover dead variable/assignment

### DIFF
--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -277,7 +277,6 @@ static RC_STRINGLIST *rc_config_kcl(RC_STRINGLIST *config)
 	char *tmp = NULL;
 	char *value = NULL;
 	size_t varlen = 0;
-	size_t len = 0;
 
 	overrides = rc_stringlist_new();
 
@@ -295,7 +294,6 @@ static RC_STRINGLIST *rc_config_kcl(RC_STRINGLIST *config)
 		}
 
 		if (value != NULL) {
-			len = varlen + strlen(value) + 2;
 			xasprintf(&tmp, "%s=%s", override->value, value);
 		}
 


### PR DESCRIPTION
I was looking at some of the warnings emitted when building with -Wall and this one was easy
enough. It's likely a leftover from the previous commit b2f5531194 ("librc-misc: convert snprintf calls to xasprintf".
