### PR TITLE
librc: fix EACCES errno false-positive crash

### DIFF
--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -850,7 +850,7 @@ rc_service_state(const char *service)
 	}
 
 	if (state & RC_SERVICE_STARTED) {
-		if (rc_service_daemons_crashed(service))
+		if (rc_service_daemons_crashed(service) && errno != EACCES)
 			state |= RC_SERVICE_CRASHED;
 	}
 	if (state & RC_SERVICE_STOPPED) {


### PR DESCRIPTION
Use errno != EACCES to fix false-positive for non-root users
with grsecurity kernels.

Fixes: 37e29442721a ("librc: Add check for crashed state")