### PR TITLE
supervise-daemon: fix respawn_max off by one

### DIFF
--- a/src/rc/supervise-daemon.c
+++ b/src/rc/supervise-daemon.c
@@ -510,7 +510,7 @@ static void supervisor(char *exec, char **argv)
 					first_spawn = 0;
 				} else
 					respawn_count++;
-				if (respawn_count >= respawn_max) {
+				if (respawn_count > respawn_max) {
 					syslog(LOG_WARNING,
 							"respawned \"%s\" too many times, exiting", exec);
 					exiting = true;


### PR DESCRIPTION
Fix the comparison between respawn_count and respawn_max so that
respawn_max = 1 will allow for one respawn. Since respawn_count is
incremented before the comparison, use a 'greater than' comparison
so that respawn will be triggered when respawn_count is equal to
respawn_max.

Fixes: https://github.com/OpenRC/openrc/issues/247