### PR TITLE
supervise-daemon: use waitpid to fix do_stop kill 0 for child

### DIFF
--- a/src/rc/rc-schedules.c
+++ b/src/rc/rc-schedules.c
@@ -272,6 +272,9 @@ int do_stop(const char *applet, const char *exec, const char *const *argv,
 		} else {
 			if (!quiet)
 				ebeginv("Sending signal %d to PID %d", sig, pi->pid);
+			if (sig == 0)
+				/* waitpid is needed for kill to fail for supervisor children */
+				waitpid(pi->pid, NULL, WNOHANG);
 			errno = 0;
 			killed = (kill(pi->pid, sig) == 0 ||
 			    errno == ESRCH ? true : false);


### PR DESCRIPTION
In do_stop, kill(pid, 0) always returns success for "zombie" child
processes that have been killed by an earlier SC_SIGNAL item in the
stop schedule. In order to make kill(pid, 0) fail on these child
processes, call waitpid before kill.