### PR TITLE
[runit integration] give a bit of time to start runsv

### DIFF
--- a/sh/runit.sh
+++ b/sh/runit.sh
@@ -21,15 +21,15 @@ runit_start()
 	ebegin "Starting ${name:-$RC_SVCNAME}"
 	ln -snf "${service_path}" "${service_link}"
 	local i=0 retval=1
+	# it can take upto 5 seconds for runsv to start
 	while [ $i -lt 6 ] ; do
-		if sv -w 6 start "${service_link}" > /dev/null 2>&1; then
+		if sv start "${service_link}" > /dev/null 2>&1; then
 			retval=0
 			break
 		fi
 		sleep 1 && i=$(expr $i + 1)
 	done
-	sv start "${service_link}" > /dev/null 2>&1
-	eend $? "Failed to start ${name:-$RC_SVCNAME}"
+	eend $retval "Failed to start ${name:-$RC_SVCNAME}"
 }
 
 runit_stop()

--- a/sh/runit.sh
+++ b/sh/runit.sh
@@ -29,6 +29,10 @@ runit_start()
 		fi
 		sleep 1 && i=$(expr $i + 1)
 	done
+	if [ $retval -eq 1 ]; then
+		# clean up the link else sv will keep on trying
+		rm "${service_link}"
+	fi
 	eend $retval "Failed to start ${name:-$RC_SVCNAME}"
 }
 

--- a/sh/runit.sh
+++ b/sh/runit.sh
@@ -20,6 +20,14 @@ runit_start()
 	service_link="${RC_SVCDIR}/sv/${service_path##*/}"
 	ebegin "Starting ${name:-$RC_SVCNAME}"
 	ln -snf "${service_path}" "${service_link}"
+	local i=0 retval=1
+	while [ $i -lt 6 ] ; do
+		if sv -w 6 start "${service_link}" > /dev/null 2>&1; then
+			retval=0
+			break
+		fi
+		sleep 1 && i=$(expr $i + 1)
+	done
 	sv start "${service_link}" > /dev/null 2>&1
 	eend $? "Failed to start ${name:-$RC_SVCNAME}"
 }


### PR DESCRIPTION
Currently, we run sv start immediately after linking the service.
The runsv process may not be up at the moment, as a result of which
openrc will mark the service as stopped, even though it may be brought up
by runit at the next scan.

This is documented in the gentoo wiki:
https://wiki.gentoo.org/wiki/Runit#OpenRC.27s_runit_integration_feature

This PR adds a timeout so that correct process state can be reported.

Before:
~~~~
# rc-service netdata-runit start
 * Starting netdata-runit ...
fail: /run/openrc/sv/netdata: runsv not running
 * Failed to start netdata-runit                                          [ !! ]
 * ERROR: netdata-runit failed to start
~~~~

After:
~~~~
 rc-service netdata-runit start
 * Starting netdata-runit ...
fail: /run/openrc/sv/netdata: runsv not running
ok: run: /run/openrc/sv/netdata: (pid 15725) 1s                           [ ok ]
~~~~
