### PR TITLE
openrc-run: Fixing command_user in start-stop-daemon

### DIFF
--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -55,7 +55,7 @@ ssd_start()
 		${error_logger_arg} \
 		${procname:+--name} $procname \
 		${pidfile:+--pidfile} $pidfile \
-		${command_user+--user} $command_user \
+		${command_user+--chuid} $command_user \
 		${umask+--umask} $umask \
 		$_background $start_stop_daemon_args \
 		-- $command_args $command_args_background


### PR DESCRIPTION
As mentionned in man openrc-run.8,
> “If the daemon does not support changing to a different user id, you can use this to change the user id, **and optionally group id**, before start-stop-daemon(8) or supervise-daemon(8) launches the daemon.”