### PR TITLE
sh/functions.sh.in: return a different value for invalid input in yesno()

### DIFF
--- a/sh/functions.sh.in
+++ b/sh/functions.sh.in
@@ -46,7 +46,7 @@ yesno()
 	case "$value" in
 		[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee]|[Oo][Nn]|1) return 0;;
 		[Nn][Oo]|[Ff][Aa][Ll][Ss][Ee]|[Oo][Ff][Ff]|0) return 1;;
-		*) vewarn "\$$1 is not set properly"; return 1;;
+		*) vewarn "\$$1 is not set properly"; return 2;;
 	esac
 }
 


### PR DESCRIPTION
Currently 0 is returned for yes, 1 for no, and 1 for invalid input. This changes invalid input to return 255, so it can be differentiated from no.

@williamh 