### PR TITLE
.cirrus.yml: give cirrus-ci a try (freebsd)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,15 @@
+# Cirrus CI integration
+# https://cirrus-ci.org
+
+test_task:
+  freebsd_instance:
+    matrix:
+      image: freebsd-12-0-release-amd64
+      image: freebsd-11-2-release-amd64
+  env:
+    OS: FreeBSD
+  procfs_script: >
+    [ -f /proc/curproc ] || mount -t procfs proc /proc
+  pkg_install_script: pkg install -y bash gawk gmake gsed
+  gsed_hack_script: rm /usr/bin/sed && ln -s /usr/local/bin/gsed /usr/bin/sed
+  test_script: bash test/cirrus.sh

--- a/test/cirrus.sh
+++ b/test/cirrus.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2007-2018 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+set -e
+set -u
+set -x
+
+# These are steps to run on Cirrus CI under a jailed FreeBSD system.
+# See $TOP/.cirrus.yml for more info about the Cirrus CI setup.
+
+cpus=$(getconf NPROCESSORS_CONF || echo 1)
+gmake -j"${cpus}" -O
+gmake test


### PR DESCRIPTION
This will require a bit more work, but it's a good start.
I'll keep pushing to this branch as I figure out how to fix things.

While working on it I found a strange behavior in cirrus-ci, they set `OS=freebsd` (lowercase) while makefile excpects it to be `FreeBSD` so there is an env workaround for now.
https://github.com/cirruslabs/cirrus-ci-docs/issues/100

