### PR TITLE
src/rc/supervise-daemon.c: fix free of null pointer

### DIFF
--- a/src/rc/supervise-daemon.c
+++ b/src/rc/supervise-daemon.c
@@ -168,7 +168,6 @@ static inline int ioprio_set(int which _unused, int who _unused,
 
 static void cleanup(void)
 {
-	free(changeuser);
 }
 
 static void re_exec_supervisor(void)


### PR DESCRIPTION
The `cleanup()` function in supervise-daemon.c is provided
to `atexit(3)` early in `main()` while the global pointer
`changeuser` is still `NULL`. If the code calls `exit(3)`
before `changeuser` is assigned a value (like on line 670
where `eerrorx()` is called), then the program will crash
rather than printing an error message.

Remove the call to `free(3)` entirely; there is no need to
free the memory immediately before exiting.