### PR TITLE
src/rc/supervise-daemon.c: do not pass NULL to strcmp

### DIFF
--- a/src/rc/supervise-daemon.c
+++ b/src/rc/supervise-daemon.c
@@ -671,7 +671,7 @@ int main(int argc, char **argv)
 		eerrorx("%s: The RC_SVCNAME environment variable is not set", applet);
 	openlog(applet, LOG_PID, LOG_DAEMON);
 
-	if (argc >= 1 && svcname && strcmp(argv[1], svcname))
+	if (argc <= 1 || strcmp(argv[1], svcname))
 		eerrorx("%s: the first argument is %s and must be %s",
 				applet, argv[1], svcname);
 


### PR DESCRIPTION
The following will cause a segfault due to NULL being
passed to `strcmp(3)`

```
$ RC_SVCNAME=foo supervise-daemon
```

Fix the bounds check on `argc` in `main`. If `argc<=1`, then
it is not safe to dereference `argv[1]`.