### PR TITLE
src/rc/openrc-run.c: remove duplicate statement

### DIFF
--- a/src/rc/openrc-run.c
+++ b/src/rc/openrc-run.c
@@ -1223,7 +1223,6 @@ int main(int argc, char **argv)
 
 		/* Make our prefix string */
 		prefix = xmalloc(sizeof(char) * l + 1);
-		ll = strlen(applet);
 		memcpy(prefix, applet, ll);
 		memset(prefix + ll, ' ', l - ll);
 		memset(prefix + l, 0, 1);


### PR DESCRIPTION
The statement
```
  ll = strlen(applet);
```
appears twice in the same block without any
intervening assignment to the variables
`ll` or `applet`

Remove the second (duplicate) statement.