### PR TITLE
Convert internal rc_getline() calls to getline() calls

### DIFF
--- a/src/librc/librc-daemon.c
+++ b/src/librc/librc-daemon.c
@@ -141,7 +141,7 @@ rc_find_pids(const char *exec, const char *const *argv, uid_t uid, pid_t pid)
 		fp = fopen("/proc/self/status", "r");
 		if (fp) {
 			while (!feof(fp)) {
-				rc_getline(&line, &len, fp);
+				getline(&line, &len, fp);
 				if (strncmp(line, "envID:\t0", 8) == 0) {
 					openvz_host = true;
 					break;
@@ -197,7 +197,7 @@ rc_find_pids(const char *exec, const char *const *argv, uid_t uid, pid_t pid)
 				if (!fp)
 					continue;
 				while (!feof(fp)) {
-					rc_getline(&line, &len, fp);
+					getline(&line, &len, fp);
 					if (strncmp(line, "envID:", 6) == 0) {
 						container_pid = !(strncmp(line, "envID:\t0", 8) == 0);
 						break;
@@ -346,7 +346,7 @@ _match_daemon(const char *path, const char *file, RC_STRINGLIST *match)
 	if (!fp)
 		return false;
 
-	while ((rc_getline(&line, &len, fp))) {
+	while ((getline(&line, &len, fp))) {
 		TAILQ_FOREACH(m, match, entries)
 		    if (strcmp(line, m->value) == 0) {
 			    TAILQ_REMOVE(match, m, entries);
@@ -559,7 +559,7 @@ rc_service_daemons_crashed(const char *service)
 		if (!fp)
 			break;
 
-		while ((rc_getline(&line, &len, fp))) {
+		while ((getline(&line, &len, fp))) {
 			p = line;
 			if ((token = strsep(&p, "=")) == NULL || !p)
 				continue;

--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -184,7 +184,7 @@ rc_config_list(const char *file)
 	if (!(fp = fopen(file, "r")))
 		return list;
 
-	while ((rc_getline(&buffer, &len, fp))) {
+	while ((getline(&buffer, &len, fp))) {
 		p = buffer;
 		/* Strip leading spaces/tabs */
 		while ((*p == ' ') || (*p == '\t'))

--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -192,7 +192,7 @@ file_regex(const char *file, const char *regex)
 		return false;
 	}
 
-	while ((rc_getline(&line, &len, fp))) {
+	while ((getline(&line, &len, fp))) {
 		char *str = line;
 		/* some /proc files have \0 separated content so we have to
 		   loop through the 'line' */
@@ -703,7 +703,7 @@ rc_service_extra_commands(const char *service)
 	free(svc);
 
 	if ((fp = popen(cmd, "r"))) {
-		rc_getline(&buffer, &len, fp);
+		getline(&buffer, &len, fp);
 		p = buffer;
 		commands = rc_stringlist_new();
 
@@ -741,7 +741,7 @@ rc_service_description(const char *service, const char *option)
 	snprintf(cmd, l, DESCSTR, svc, *option ? "_" : "", option);
 	free(svc);
 	if ((fp = popen(cmd, "r"))) {
-		rc_getline(&desc, &len, fp);
+		getline(&desc, &len, fp);
 		pclose(fp);
 	}
 	free(cmd);


### PR DESCRIPTION
getline has been in posix since POSIX.1-2008, so it should be safe for
us to use it instead of using our wrapper function.