### PR TITLE
mention openrc-run.8 in openrc.8

### DIFF
--- a/man/openrc.8
+++ b/man/openrc.8
@@ -66,6 +66,7 @@ and
 .Xr shutdown 8
 and let them call these special runlevels.
 .Sh SEE ALSO
+.Xr openrc-run 8 ,
 .Xr rc-status 8 ,
 .Xr rc-update 8 ,
 .Xr init 8 ,


### PR DESCRIPTION
This is a proposal to mention `openrc-run.8` in openrc. The reason for this is that I've searched for documentation and looked at `man openrc` but wasn't bright enough to find `openrc-run.8`.

If this is not wanted, please just delete this PR.