### PR TITLE
sysctl: reuse BSD script for BusyBox

### DIFF
--- a/BUSYBOX.md
+++ b/BUSYBOX.md
@@ -23,8 +23,5 @@ or recognize the nofail option in fstab.
 
 CONFIG_SETFONT -- The setfont applet does not support the -u option from kbd.
 
-CONFIG_BB_SYSCTL -- The sysctl applet does not support the --system command
-line switch.
-
 There is work to get most of these supported by busybox, so this file
 will be updated as things change.

--- a/init.d/sysctl.in
+++ b/init.d/sysctl.in
@@ -24,12 +24,12 @@ BSD_sysctl()
 	for conf in /etc/sysctl.conf /etc/sysctl.d/*.conf; do
 		if [ -r "$conf" ]; then
 			vebegin "applying $conf"
-			while read var comments; do
+			sed 's/ = /=/' "$conf" | while read var comments; do
 				case "$var" in
 				""|"#"*) continue;;
 				esac
 				sysctl -w "$var" >/dev/null || retval=1
-			done < "$conf"
+			done
 			veend $retval
 		fi
 	done
@@ -52,7 +52,12 @@ start()
 	ebegin "Configuring kernel parameters"
 	case "$RC_UNAME" in
 	*BSD|GNU) BSD_sysctl; rc=$? ;;
-	Linux) Linux_sysctl; rc=$? ;;
+	Linux)
+		if sysctl -V > /dev/null 2>&1; then # procps-ng
+			Linux_sysctl; rc=$?
+		else # busybox
+			BSD_sysctl; rc=$?
+		fi ;;
 	esac
 	eend $rc "Unable to configure some kernel parameters"
 }


### PR DESCRIPTION
If asking sysctl for its version on Linux fails, assume it's from
BusyBox and call it like BSD sysctl. When passing a conf line, trim
spaces around `=` with sed, because both BSD and BusyBox expect the
`variable=value` sysctl format. Despite the BusyBox sysctl applet
missing the --system command line switch, OpenRC can use this applet
now, so remove the recommendation to disable its build.