### PR TITLE
librc/librc-depend.c: fix NULL pointer dereference

### DIFF
--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -84,10 +84,11 @@ static RC_DEPINFO *
 get_depinfo(const RC_DEPTREE *deptree, const char *service)
 {
 	RC_DEPINFO *di;
-
-	TAILQ_FOREACH(di, deptree, entries)
-		if (strcmp(di->service, service) == 0)
-			return di;
+	if (deptree) {
+		TAILQ_FOREACH(di, deptree, entries)
+			if (strcmp(di->service, service) == 0)
+				return di;
+	}
 	return NULL;
 }
 
@@ -96,9 +97,11 @@ get_deptype(const RC_DEPINFO *depinfo, const char *type)
 {
 	RC_DEPTYPE *dt;
 
-	TAILQ_FOREACH(dt, &depinfo->depends, entries)
-		if (strcmp(dt->type, type) == 0)
-			return dt;
+	if (depinfo) {
+		TAILQ_FOREACH(dt, &depinfo->depends, entries)
+			if (strcmp(dt->type, type) == 0)
+				return dt;
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
In some cases deptree or depinfo can be NULL, check
before dereferencing.

Bug: https://bugs.gentoo.org/659906
Issue: https://github.com/OpenRC/openrc/issues/293

It's just a partial fix for mentioned issues, as while it no longer segfaults, I'm still trying to find why files ended up being only root readable in the first place and how to properly handle in openrc code instead of NULLin everything and assuming we are at sysinit runlevel.