### PR TITLE
net-online.in: add ! on symbolic check in getinterface()

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -23,7 +23,7 @@ get_interfaces()
 {
 	local ifname iftype
 	for ifname in /sys/class/net/*; do
-		[ -h "${ifname}" ] && continue
+		[ ! -h "${ifname}" ] && continue
 		read iftype < ${ifname}/type
 		[ "$iftype" = "1" ] && printf "%s " ${ifname##*/}
 	done


### PR DESCRIPTION
`get_interfaces()` should skip to the next iteration of the loop
only if it's not symbiolic links, not the other way around

This commit fixes the problem by adding `!` operator on test command
so that it will only skip to the next loop if the file aren't
symbolic links

fixes #316

References:

commit f42ec82f21f3760b829507344ad0ae761e1d59aa
https://www.tldp.org/LDP/abs/html/loopcontrol.html