### PR TITLE
Add support for the INIT_HALT environment variable

### DIFF
--- a/init.d/Makefile
+++ b/init.d/Makefile
@@ -22,7 +22,7 @@ SRCS-FreeBSD+=	adjkerntz.in devd.in dumpon.in encswap.in ipfw.in \
 		mixer.in nscd.in powerd.in syscons.in
 
 SRCS-Linux=	agetty.in binfmt.in devfs.in cgroups.in dmesg.in hwclock.in \
-	consolefont.in keymaps.in killprocs.in modules.in \
+	consolefont.in halt.in keymaps.in killprocs.in modules.in \
 	mount-ro.in mtab.in numlock.in procfs.in net-online.in save-keymaps.in \
 	save-termencoding.in sysfs.in termencoding.in
 

--- a/init.d/halt.in
+++ b/init.d/halt.in
@@ -1,0 +1,30 @@
+#!@SBINDIR@/openrc-run
+# Copyright (c) 2019 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+description="Halt or Poweroff"
+
+depend()
+{
+	after killprocs savecache mount-ro
+}
+
+start()
+{
+	if [ "$INIT_HALT" = HALT ]; then
+		ebegin "Halting system"
+		halt -dhn
+		eend $?
+	elif [ "$INIT_HALT" = POWEROFF ]; then
+		ebegin "Powering off system"
+		poweroff -dhn
+		eend $?
+	fi
+}

--- a/runlevels/Makefile
+++ b/runlevels/Makefile
@@ -39,7 +39,7 @@ BOOT-FreeBSD+=	adjkerntz dumpon syscons
 
 BOOT-Linux+=	binfmt hwclock keymaps modules mtab procfs save-keymaps \
 	save-termencoding termencoding
-SHUTDOWN-Linux=	killprocs mount-ro
+SHUTDOWN-Linux=	killprocs mount-ro halt
 SYSINIT-Linux=	devfs cgroups dmesg sysfs
 
 # Generic BSD stuff

--- a/src/rc/rc-misc.c
+++ b/src/rc/rc-misc.c
@@ -55,6 +55,7 @@ static const char *const env_whitelist[] = {
 	"RC_DEBUG", "RC_NODEPS",
 	"LANG", "LC_MESSAGES", "TERM",
 	"EINFO_COLOR", "EINFO_VERBOSE",
+	"INIT_HALT",
 	NULL
 };
 


### PR DESCRIPTION
Please note that this change is untested; I'm looking for some feedback before I invest the effort in actually testing it.

The shutdown command provided by sysvinit sets the INIT_HALT environment
variable before switching to runlevel 0.

shutdown -hH -> INIT_HALT=HALT
shutdown -hP -> INIT_HALT=POWEROFF

Add a new "halt" init script to interpret this variable and invoke "halt"
or "poweroff" as appropriate.

This restores the ability to actually halt the system instead of always
turning off the power.

Reference:
http://git.savannah.nongnu.org/cgit/sysvinit.git/tree/doc/Changelog?h=2.95#n30
http://git.savannah.nongnu.org/cgit/sysvinit.git/tree/src/shutdown.c?h=2.95#n457
http://git.savannah.nongnu.org/cgit/sysvinit.git/tree/src/shutdown.c?h=2.95#n554

Signed-off-by: Mike Gilbert <floppym@gentoo.org>