### PR TITLE
Add INIT_HALT to the environment whitelist

### DIFF
--- a/src/rc/rc-misc.c
+++ b/src/rc/rc-misc.c
@@ -55,6 +55,7 @@ static const char *const env_whitelist[] = {
 	"RC_DEBUG", "RC_NODEPS",
 	"LANG", "LC_MESSAGES", "TERM",
 	"EINFO_COLOR", "EINFO_VERBOSE",
+	"INIT_HALT",
 	NULL
 };
 


### PR DESCRIPTION
Under sysvinit, this variable is inherited from init[1] when the system
is shutting down.

Signed-off-by: Mike Gilbert <floppym@gentoo.org>