### PR TITLE
fix agetty can be started directly

### DIFF
--- a/init.d/agetty.in
+++ b/init.d/agetty.in
@@ -25,7 +25,7 @@ depend() {
 }
 
 start_pre() {
-	if [ -z "$port" ]; then
+	if [ "$port" = "$RC_SVCNAME" ]; then
 		eerror "${RC_SVCNAME} cannot be started directly. You must create"
 		eerror "symbolic links to it for the ports you want to start"
 		eerror "agetty on and add those to the appropriate runlevels."


### PR DESCRIPTION
I find I can start agetty directly:
```
# rc-service agetty start
```
however,this behavior is incorrect obviously.
Then I read the /etc/init.d/agetty, the $port will never be empty, so the function start_pre() will be Meaningless.
So I suggest change` if [ -z "$port" ]`to `if [ "$port" = "$RC_SVCNAME" ]`