### PR TITLE
check if cgroups are mounted when rc_cgroup_mode="unified"

### DIFF
--- a/sh/rc-cgroup.sh
+++ b/sh/rc-cgroup.sh
@@ -181,7 +181,7 @@ cgroup2_set_limits()
 {
 	local cgroup_path
 	cgroup_path="$(cgroup2_find_path)"
-	[ -d "${cgroup_path}" ] || return 0
+	mountinfo -q "${cgroup_path}"|| return 0
 	rc_cgroup_path="${cgroup_path}/${RC_SVCNAME}"
 	[ ! -d "${rc_cgroup_path}" ] && mkdir "${rc_cgroup_path}"
 	[ -f "${rc_cgroup_path}"/cgroup.procs ] &&


### PR DESCRIPTION
prior to cgroups getting mounted, /sys/fs/cgroup will still exist, but attempts to make directories in it will fail, change cgroup2_set_limits() to verify that cgroups are mounted instead of just checking that /sys/fs/cgroup exists. fixes #307