### PR TITLE
remove broken service startup detection for runit services

### DIFF
--- a/sh/runit.sh
+++ b/sh/runit.sh
@@ -20,8 +20,6 @@ runit_start()
 	service_link="${RC_SVCDIR}/sv/${service_path##*/}"
 	ebegin "Starting ${name:-$RC_SVCNAME}"
 	ln -snf "${service_path}" "${service_link}"
-	sv start "${service_link}" > /dev/null 2>&1
-	eend $? "Failed to start ${name:-$RC_SVCNAME}"
 }
 
 runit_stop()


### PR DESCRIPTION
The current check used to fail if runsv was not up.
It can take upto 5 seconds for runsv to be invoked on the service.
To report correct status, we can wait for 5 seconds or
check it via `rc-status`

See https://github.com/OpenRC/openrc/pull/253 for the sleep approach and its discussion.