### PR TITLE
service net-online: fix get_interfaces() and add minimum_up

### DIFF
--- a/conf.d/net-online
+++ b/conf.d/net-online
@@ -3,6 +3,11 @@
 # default is all interfaces that support ethernet.
 #interfaces=""
 
+# The minimum_up setting controls how many interfaces the net-online
+# service expects to be "up" when deciding whether the network is active.
+# The default is the number of detected/specified interfaces.
+#minimum_up=
+
 # This setting controls whether a ping test is included in the test for
 # network connectivity after all interfaces are active.
 #include_ping_test=no

--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -38,40 +38,41 @@ start ()
 	rc=0
 	interfaces=${interfaces:-$(get_interfaces)}
 	timeout=${timeout:-120}
- [ $timeout -eq 0 ] && infinite=true || infinite=false
- while $infinite || [ $timeout -gt 0 ]; do
-	carriers=0
-	configured=0
-	ifcount=0
- 	for dev in ${interfaces}; do
-		: $((ifcount += 1))
-		read carrier < /sys/class/net/$dev/carrier 2> /dev/null ||
-			carrier=
-		[ "$carrier" = 1 ] && : $((carriers += 1))
-		read operstate < /sys/class/net/$dev/operstate 2> /dev/null ||
-			operstate=
-		[ "$operstate" = up ] && : $((configured += 1))
-	done
-	[ $configured -eq $ifcount ] && [ $carriers -ge 1 ] && break
-	sleep 1
-	: $((timeout -= 1))
- done
- ! $infinite && [ $timeout -eq 0 ] && rc=1
- include_ping_test=${include_ping_test:-${ping_default_gateway}}
- if [ -n "${ping_default_gateway}" ]; then
- ewarn "ping_default_gateway is deprecated, please use include_ping_test"
- fi
- if [ $rc -eq 0 ] && yesno ${include_ping_test:-no}; then
- 	ping_test_host="${ping_test_host:-google.com}"
- 	if [ -n "$ping_test_host" ]; then
-		while $infinite || [ $timeout -gt 0 ]; do
-			ping -c 1 $ping_test_host > /dev/null 2>&1
-			rc=$?
-			[ $rc -eq 0 ] && break
-			sleep 1
-			: $((timeout -= 1))
+	[ $timeout -eq 0 ] && infinite=true || infinite=false
+	while $infinite || [ $timeout -gt 0 ]; do
+		carriers=0
+		configured=0
+		ifcount=0
+		for dev in ${interfaces}; do
+			[ -e /sys/class/net/$dev ] || continue
+			: $((ifcount += 1))
+			read carrier < /sys/class/net/$dev/carrier 2> /dev/null ||
+				carrier=
+			[ "$carrier" = 1 ] && : $((carriers += 1))
+			read operstate < /sys/class/net/$dev/operstate 2> /dev/null ||
+				operstate=
+			[ "$operstate" = up ] && : $((configured += 1))
 		done
+		[ $configured -ge ${minimum_up:-${ifcount}} ] && [ $carriers -ge 1 ] && break
+		sleep 1
+		: $((timeout -= 1))
+	done
+	! $infinite && [ $timeout -eq 0 ] && rc=1
+	include_ping_test=${include_ping_test:-${ping_default_gateway}}
+	if [ -n "${ping_default_gateway}" ]; then
+		ewarn "ping_default_gateway is deprecated, please use include_ping_test"
 	fi
- fi
- eend $rc "The network is offline"
+ 	if [ $rc -eq 0 ] && yesno ${include_ping_test:-no}; then
+		ping_test_host="${ping_test_host:-google.com}"
+		if [ -n "$ping_test_host" ]; then
+			while $infinite || [ $timeout -gt 0 ]; do
+				ping -c 1 $ping_test_host > /dev/null 2>&1
+				rc=$?
+				[ $rc -eq 0 ] && break
+				sleep 1
+				: $((timeout -= 1))
+			done
+		fi
+	fi
+	eend $rc "The network is offline"
 }


### PR DESCRIPTION
This change incorporates a fork that I made for k3OS that helps
solve a number of network availability race-conditions.

See rancher/k3os#184.

~This fixes #316 by removing the `test -h $ifname` check altogether.
Not only was the check backwards, resulting in undetected interfaces,
but on k3OS at least, everything in /sys/class/net is a symlink, making
the corrected check redundant.~

This sidesteps "file not found" errors when attempting to read
`carrier` and `operstate` for explicitly specified interfaces that do not
exist.

Lastly, a new `conf.d` variable, `minimum_up`, allows for net-online to
return successfully when at least that number of interfaces are in the
"up" state. The default empty values results in the old behavior of
expecting all specified (or detected) interfaces to be "up". This is useful
when connecting edge devices to the internet by either ethernet or wifi
but not necessarily both (and not necessarily the same device as last boot).

~Fixes #316~
Supercedes #317