### PR TITLE
Make swap use lvm

### DIFF
--- a/init.d/swap.in
+++ b/init.d/swap.in
@@ -11,7 +11,8 @@
 
 depend()
 {
-	after clock root
+	use lvm
+	after clock lvm root
 	before localmount
 	keyword -docker -jail -lxc -openvz -prefix -systemd-nspawn -vserver
 }


### PR DESCRIPTION
If swap is in logical volume, it might not be present yet. So swap
service should use and after lvm.