### PR TITLE
Fix segfault when executable does not exist

### DIFF
--- a/src/rc/supervise-daemon.c
+++ b/src/rc/supervise-daemon.c
@@ -983,7 +983,7 @@ int main(int argc, char **argv)
 			}
 			if (!exists(exec_file)) {
 				eerror("%s: %s does not exist", applet,
-				    *exec_file ? exec_file : exec);
+				    exec_file ? exec_file : exec);
 				free(exec_file);
 				exit(EXIT_FAILURE);
 			}


### PR DESCRIPTION
When executable is provided just by name (and therefore searched in a
path), exec_file is reset to NULL every time. exists() handles it being
NULL just fine, but dereferencing it in eerror does not work.

Fixes #326