### PR TITLE
binfmt: ensure a file is unregistered before registering

### DIFF
--- a/sh/binfmt.sh.in
+++ b/sh/binfmt.sh.in
@@ -29,6 +29,9 @@ apply_file() {
 			\;*) continue ;;
 		esac
 
+		local reg=${line#*:}
+		[ -e /proc/sys/fs/binfmt_misc/${reg%%:*} ] && echo -1 > /proc/sys/fs/binfmt_misc/${reg%%:*}
+
 		echo "${line}" > /proc/sys/fs/binfmt_misc/register
 		rc=$?
 		if [ $rc -ne 0 ]; then


### PR DESCRIPTION
If binfmt.sh is run again after the system booted up, eg by a pacman alpm hook, 
it will not throw a write error.
Unregister the file before registering.