### PR TITLE
Delete stray text.

### DIFF
--- a/init-guide.md
+++ b/init-guide.md
@@ -45,6 +45,3 @@ If you want this functionality on a live system, you should first
 migrate the system to openrc-init, remove sysvinit, then rebuild and
 install this package with MKSYSVINIT=yes.
 
-package.
-migrating your system to openrc-init.
-


### PR DESCRIPTION
It looks like some stray text was left at the bottom of the file:
```
package.
migrating your system to openrc-init.
```
There's a subsection on migrating a system to `openrc-init`; perhaps this was
an embryonic section title?