### PR TITLE
src/rc/rc-logger.h: fix build failure against gcc-10

### DIFF
--- a/src/rc/rc-logger.h
+++ b/src/rc/rc-logger.h
@@ -13,8 +13,8 @@
 #ifndef RC_LOGGER_H
 #define RC_LOGGER_H
 
-pid_t rc_logger_pid;
-int rc_logger_tty;
+extern pid_t rc_logger_pid;
+extern int rc_logger_tty;
 extern bool rc_in_logger;
 
 void rc_logger_open(const char *runlevel);


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
cc  -L../librc -L../libeinfo -O2 -g -std=c99 -Wall -Wextra -Wimplicit -Wshadow \
  -Wformat=2 -Wmissing-prototypes -Wmissing-declarations -Wmissing-noreturn \
  -Wmissing-format-attribute -Wnested-externs -Winline -Wwrite-strings \
  -Wcast-align -Wcast-qual -Wpointer-arith -Wdeclaration-after-statement \
  -Wsequence-point -Werror=implicit-function-declaration    \
  -Wl,-rpath=/lib   -o openrc rc.o rc-logger.o rc-misc.o rc-plugin.o _usage.o -lutil -lrc -leinfo -Wl,-Bdynamic -ldl
ld: rc-logger.o:/home/slyfox/dev/git/openrc/src/rc/rc-logger.h:16:
  multiple definition of `rc_logger_pid'; rc.o:openrc/src/rc/rc-logger.h:16: first defined here
ld: rc-logger.o:/home/slyfox/dev/git/openrc/src/rc/rc-logger.h:17:
  multiple definition of `rc_logger_tty'; rc.o:openrc/src/rc/rc-logger.h:17: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.