### PR TITLE
runlevels: install gettys if the MKGETTYS variable is set to > 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ PROGLDFLAGS=-static
 LIBNAME=lib64
 DESTDIR=/tmp/openrc-image
 MKBASHCOMP=no
+MKGETTYS=6
 MKNET=no
 MKPAM=pam
 MKPREFIX=yes

--- a/init-guide.md
+++ b/init-guide.md
@@ -22,13 +22,17 @@ tty1-tty6.
 
 ```
 # cd /etc/init.d
-# for x in tty1 tty2 tty3 tty4 tty5 tty6; do
-  ln -snf agetty agetty.$x
+# for x in 1 2 3 4 5 6; do
+  ln -snf agetty agetty.tty$x
   done
 ```
 
 Once this is done, use ```rc-update``` as normal to install the agetty
 services in the appropriate runlevels.
+
+This can be done at build time by passing MKGETTYS=n, with n > 0. By default
+OpenRC is built with MKGETTYS=6. If you set it to zero no agetty.tty$x symlink
+will be installed.
 
 * Reboot your system.
 

--- a/mk/getty.mk
+++ b/mk/getty.mk
@@ -1,0 +1,2 @@
+MKGETTYS?= 6
+

--- a/runlevels/Makefile
+++ b/runlevels/Makefile
@@ -1,3 +1,4 @@
+include ../mk/getty.mk
 include ../mk/net.mk
 
 BOOT=		bootmisc fsck hostname localmount loopback \
@@ -90,10 +91,10 @@ install:
 			fi; \
 			ln -snf ${INITDIR}/"$$x" ${SHUTDOWNDIR}/"$$x" || exit $$?; done \
 	fi
-	if test "${MKSYSVINIT}" = yes && test "${OS}" = Linux; then \
-		for x in tty1 tty2 tty3 tty4 tty5 tty6; do \
-			ln -snf ${INITDIR}/agetty ${DESTDIR}/${INITDIR}/"agetty.$$x" || exit $$?; \
-			ln -snf ${INITDIR}/agetty.$$x ${DEFAULTDIR}/"agetty.$$x" || exit $$?; \
+	if test "0${MKGETTYS}" -gt 0 && test "${OS}" = Linux; then \
+		for x in $$(seq 1 ${MKGETTYS}); do \
+			ln -snf ${INITDIR}/agetty ${DESTDIR}/${INITDIR}/"agetty.tty$$x" || exit $$?; \
+			ln -snf ${INITDIR}/agetty.tty$$x ${DEFAULTDIR}/"agetty.tty$$x" || exit $$?; \
 		done; \
 	fi
 


### PR DESCRIPTION
A separate switch allows to set the number of desired gettys (or none,
since tty[1-6] may not even exist, like in embedded devices with serial
consoles, only).

Update the documentation accordingly.

Keep MKSYSVINIT just to control the build of the sysvinit compatible
wrappers.

Signed-off-by: Carlos Santos <unixmania@gmail.com>