### PR TITLE
Fix off by ones when checking for RC_* envvars

### DIFF
--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -863,8 +863,8 @@ int main(int argc, char **argv)
 
 		TAILQ_FOREACH(env, env_list, entries) {
 			if ((strncmp(env->value, "RC_", 3) == 0 &&
-				strncmp(env->value, "RC_SERVICE=", 10) != 0 &&
-				strncmp(env->value, "RC_SVCNAME=", 10) != 0) ||
+				strncmp(env->value, "RC_SERVICE=", 11) != 0 &&
+				strncmp(env->value, "RC_SVCNAME=", 11) != 0) ||
 				strncmp(env->value, "SSD_NICELEVEL=", 14) == 0 ||
 				strncmp(env->value, "SSD_IONICELEVEL=", 16) == 0)
 			{


### PR DESCRIPTION
The same as https://github.com/OpenRC/openrc/pull/361