### PR TITLE
rc-status: Remove noise from ini-formatted output

### DIFF
--- a/src/rc/rc-status.c
+++ b/src/rc/rc-status.c
@@ -291,9 +291,10 @@ int main(int argc, char **argv)
 			goto exit;
 			/* NOTREACHED */
 		case 'f':
-			if (strcasecmp(optarg, "ini") == 0)
+			if (strcasecmp(optarg, "ini") == 0) {
 				format = FORMAT_INI;
-			else
+				setenv("EINFO_QUIET", "YES", 1);
+			} else
 				eerrorx("%s: invalid argument to --format switch\n", applet);
 			break;
 		case 'l':


### PR DESCRIPTION
Otherwise this would create the following output:

```
rc-status -f ini
 * Caching service dependencies ...        [ ok ]
[default]
dbus =  started
NetworkManager =  started
syslog-ng =  started
...

```