### PR TITLE
staticroute to ommit erroneous dash args prefix when inet6

### DIFF
--- a/init.d/staticroute.in
+++ b/init.d/staticroute.in
@@ -57,7 +57,7 @@ dump_args()
 
 do_routes()
 {
-	local xtra= family=
+	local xtra= family= argprefix=
 	[ "$RC_UNAME" != Linux ] && xtra=-q
 
 	ebegin "$1 static routes"
@@ -84,11 +84,12 @@ do_routes()
 				# Linux route does cannot work it out ...
 				if [ "$RC_UNAME" = Linux ]; then
 					case "$args" in
-					*:*) family="-A inet6";;
-					*) family=;;
+   					*:*) family="-A inet6";argprefix=;;
+					net*|host*) family=;argprefix="-";;
+					*) family=;argprefix=;;
 					esac
 				fi
-				route $family $xtra $2 -$args
+				route $family $xtra $2 $argprefix$args
 				;;
 			esac
 			veend $?


### PR DESCRIPTION
This is to address issue #312 where the route command is invoked by init.d/staticroute with an erroneous dash in case of inet6.

`route` command syntax for
Adding routes to IPv6 subnets:
`route add -net networkaddress netmask netmask interface`
Adding routes to IPv6 subnets:
`route add -A inet6 networkaddress/prefixlength interface`

The issue is, that the init.d/staticroute script **always** injects the dash in front of the arguments, so in the case of IPv6 it becomes `-networkaddress/prefixlength` which results in an error.
Tracing the actually executed route code in the net-tools package has this also in regards to the expected syntax:
`inet_route [-vF] add {-host|-net} Target[/prefix] [gw Gw] [metric M]`
vs
`inet6_route [-vF] add Target [gw Gw] [metric M] [[dev] If]`

In addition to the inet6 issue, one can also see that actually also declaring the target in the inet aka IPv4 case explicitly as a network or a host is optional, so the dash would also cause problems with that.  When given an address in dotted quad notation, route attempts to guess whether it is a network or a hostname in case net or host is not speficied.

All that being said, `route` is deprecated and the `ip route` command from the networking tools of the iproute2 suite should be used anyway, which can be done by using the staticiproute key in the respective config file to declare a static route, which will cause init.d/staticroute to invoke the `ip route` command instead of the `route` command, and for that the issue does not exist. 







