### PR TITLE
Accept RC_DEBUG setting from a service script

### DIFF
--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -244,6 +244,8 @@ sourcex "@LIBEXECDIR@/sh/supervise-daemon.sh"
 
 # Load our script
 sourcex "$RC_SERVICE"
+# May be RC_DEBUG is set inside $RC_SERVICE?
+yesno $RC_DEBUG && set -x
 
 # Set verbose mode
 if yesno "${rc_verbose:-$RC_VERBOSE}"; then


### PR DESCRIPTION
Sometimes it's need to debug a certain service script on a system startup.
With old-style sysvinit scripts we just add -x to the first line of our
service script. openrc-run doesn't allow us to do this, but we still can
place "set -x" somewhere at the beginning of our script.

This patch allow us to use RC_DEBUG instead of "set -x" for debug
purposes.