### PR TITLE
Fixed issue where a killed process is started when supervise-daemon exits

### DIFF
--- a/src/rc/supervise-daemon.c
+++ b/src/rc/supervise-daemon.c
@@ -645,7 +645,7 @@ static void supervisor(char *exec, char **argv)
 			ts.tv_sec = respawn_delay;
 			ts.tv_nsec = 0;
 			nanosleep(&ts, NULL);
-			if(!exiting) {
+			if (!exiting) {
 				child_pid = fork();
 				if (child_pid == -1) {
 					syslog(LOG_ERR, "%s: fork: %s", applet, strerror(errno));


### PR DESCRIPTION
This PR fixes an issue with supervise-daemon as follows:
- a process using respawn-delay dies
- supervise-daemon receives SIGTERM from `/etc/init.d/example stop`
- supervise-daemon begins to exit, but starts the process before exiting

This leaves an unmanaged process running while supervise-daemon is down.