### PR TITLE
Remove warning when osclock init.d script runs

### DIFF
--- a/init.d/osclock.in
+++ b/init.d/osclock.in
@@ -17,3 +17,15 @@ depend()
 {
 	provide clock
 }
+
+start()
+{
+	# This stub function is required to avoid OpenRC warning at boot:
+	#
+	#  * The command variable is undefined.
+	#  * There is nothing for osclock to start.
+	#  * If this is what you intend, please write a start function.
+	#  * This will become a failure in a future release.
+	#
+	return 0
+}


### PR DESCRIPTION
Currently when osclock is enabled as a init.d service the following
messages appear during boot when osclock starts:

  * The command variable is undefined.
  * There is nothing for osclock to start.
  * If this is what you intend, please write a start function.
  * This will become a failure in a future release.

osclock is activated whenever a machine's system clock is automatically
configured from a RTC by the kernel and the osclock's only purpose is to
satisfy the "clock" dependency defined by other init.d services.

Adding a stub start() function prevents OpenRC from showing warnings but
continues to ensure that the osclock service still does not actually do
anything.