### PR TITLE
start-stop-daemon: Don't segfault if --exec was given a non-existing file name

### DIFF
--- a/src/rc/start-stop-daemon.c
+++ b/src/rc/start-stop-daemon.c
@@ -628,7 +628,7 @@ int main(int argc, char **argv)
 	}
 	if (start && !exists(exec_file)) {
 		eerror("%s: %s does not exist", applet,
-		    *exec_file ? exec_file : exec);
+		    exec_file ? exec_file : exec);
 		free(exec_file);
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
  Starting program: /sbin/start-stop-daemon --start --exec i-dont-exist

  Program received signal SIGSEGV, Segmentation fault.
  0x0000555555559053 in main (argc=1, argv=0x7fffffffdc20)
      at start-stop-daemon.c:631
  631                         *exec_file ? exec_file : exec);

X-Gentoo-Bug: 755197
X-Gentoo-Bug-URL: https://bugs.gentoo.org/755197