### PR TITLE
Backlight state save and restore function added. (openrc service)

### DIFF
--- a/init.d/Makefile
+++ b/init.d/Makefile
@@ -21,8 +21,8 @@ SRCS-FreeBSD=	hostid.in modules.in moused.in newsyslog.in pf.in rarpd.in \
 SRCS-FreeBSD+=	adjkerntz.in devd.in dumpon.in encswap.in ipfw.in \
 		mixer.in nscd.in powerd.in syscons.in
 
-SRCS-Linux=	agetty.in binfmt.in devfs.in cgroups.in dmesg.in hwclock.in \
-	consolefont.in keymaps.in killprocs.in modules.in \
+SRCS-Linux=	agetty.in backlight.in binfmt.in devfs.in cgroups.in dmesg.in \
+        hwclock.in consolefont.in keymaps.in killprocs.in modules.in \
 	mount-ro.in mtab.in numlock.in procfs.in net-online.in save-keymaps.in \
 	save-termencoding.in sysfs.in termencoding.in
 

--- a/init.d/backlight.in
+++ b/init.d/backlight.in
@@ -1,0 +1,46 @@
+#!@SBINDIR@/openrc-run
+# Copyright (c) 2007-2015 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+description="Save & restore backlight state."
+
+depend()
+{
+	after *
+}
+
+start()
+{
+	if [ ! -d /var/cache/backlight ] ; then
+		mkdir -p /var/cache/backlight
+	fi
+	for device in $(ls /sys/class/backlight/) ; do
+		if [ -f /var/cache/backlight/${device} ] ; then
+			cat /var/cache/backlight/${device} > /sys/class/backlight/${device}/brightness
+		fi
+	done
+	return 0
+}
+
+stop()
+{
+	if [ ! -d /var/cache/backlight ] ; then
+		mkdir -p /var/cache/backlight
+	fi
+	for device in $(ls /sys/class/backlight/) ; do
+		cat /sys/class/backlight/${device}/brightness > /var/cache/backlight/${device}
+	done
+	return 0
+}
+restart(){
+	stop
+	start
+}
+


### PR DESCRIPTION
https://www.freedesktop.org/software/systemd/man/systemd-backlight@.service.html

I added service that same as this. We can save backlight state during shutdown and restore state during boot.

I save current state in /var/cache/backlight directory (if you want, I can change path)