### PR TITLE
user-guide: clarify note for Runlevels/rc-update usage

### DIFF
--- a/user-guide.md
+++ b/user-guide.md
@@ -85,8 +85,8 @@ runlevel; this will start and stop services as needed.
 Managing runlevels is usually done through the `rc-update` helper, but could of 
 course be done by hand if desired.
 e.g. `rc-update add nginx default` - add nginx to the default runlevel
-Note: This will not auto-start nginx! You'd still have to trigger `rc` or run 
-the service script by hand.
+Note: `rc-update` will not start nginx! You'd still have to trigger `rc`, or run
+the service script by hand, or start it with `rc-service nginx start`.
 
 FIXME: Document stacked runlevels
 


### PR DESCRIPTION
I found the original note a little confusing, since using rc-update will
add it to a runlevel so it *is* auto-started when the system reaches
that runlevel again, but I don't think that was the intended meaning of
'auto-start', so hopefully this makes it a little more clear.