### PR TITLE
net-online: fix process of symlinks in sysfs

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -23,7 +23,7 @@ get_interfaces()
 {
 	local ifname iftype
 	for ifname in /sys/class/net/*; do
-		[ -h "${ifname}" ] && continue
+		[ -h "${ifname}" ] || continue
 		read iftype < ${ifname}/type
 		[ "$iftype" = "1" ] && printf "%s " ${ifname##*/}
 	done


### PR DESCRIPTION
The test `[ -h "${ifname}" ] && continue` skips the symlinks while it is
the opposite that is the expected: ignoring files that are not symlinks.

Fixes commit f42ec82f21f3760b829507344ad0ae761e1d59aa.