### PR TITLE
Changed /etc to /etc/conf.d for pf.conf location.

### DIFF
--- a/init.d/pf.in
+++ b/init.d/pf.in
@@ -10,7 +10,7 @@
 # except according to the terms contained in the LICENSE file.
 
 name="Packet Filter"
-: ${pf_conf:=${pf_rules:-/etc/pf.conf}}
+: ${pf_conf:=${pf_rules:-/etc/conf.d/pf.conf}}
 required_files=$pf_conf
 
 extra_commands="checkconfig showstatus"


### PR DESCRIPTION
Changed /etc to /etc/conf.d for pf.conf location. This complies with OpenRC conventional purpose for /etc/conf.d directory.