### PR TITLE
start-stop-daemon: fix typo in manpage

### DIFF
--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -120,7 +120,7 @@ Saves the pid of the daemon in the file specified by the
 .Fl p , -pidfile
 option. Only useful when used with daemons that run in the foreground and
 forced into the background with the
-.Fl -b , -background
+.Fl b , -background
 option.
 .It Fl I , -ionice Ar class Ns Op : Ns Ar data
 Modifies the IO scheduling priority of the daemon.


### PR DESCRIPTION
Until now there was a small typo in the description of `-m, --make-pidfile` regarding the background option:

```
     -m, --make-pidfile
             Saves the pid of the daemon in the file specified by the -p, --pidfile option. Only useful when used with daemons that run
             in the foreground and forced into the background with the --b, --background option.
```

while in reality the abbreviation of `--background` is `-b` and not `--b`. This small PR fixes that :)

