### PR TITLE
numlock: Don't disable numlock on shutdown

### DIFF
--- a/init.d/numlock.in
+++ b/init.d/numlock.in
@@ -42,6 +42,8 @@ start()
 
 stop()
 {
+	yesno $RC_GOINGDOWN && return 0
+
 	ebegin "Disabling numlock on ttys"
 	_setleds -
 	eend $? "Failed to disable numlock"


### PR DESCRIPTION
When dealing with remote consoles, a shutdown could disable
host's numlock which is not desired.

Signed-off-by: Thomas Deutschmann <whissi@whissi.de>