### PR TITLE
init.d/modules.in: Avoid loading modules twice in Linux with dash shell

### DIFF
--- a/init.d/modules.in
+++ b/init.d/modules.in
@@ -41,18 +41,18 @@ find_modfiles()
 
 load_modules()
 {
-	local file m modules rc x
+	local file m _modules rc x
 	file=$1
 	[ -z "$file" ] && return 0
 	while read m x; do
 		case $m in
 			\;*) continue ;;
 			\#*) continue ;;
-			*) modules="$modules $m"
+			*) _modules="$_modules $m"
 			;;
 		esac
 	done < $file
-	for x in $modules; do
+	for x in $_modules; do
 		ebegin "Loading module $x"
 		case "$RC_UNAME" in
 			FreeBSD) kldload "$x"; rc=$? ;;


### PR DESCRIPTION
Since commit 6b475ab26992f1dd8815700828df46abc4b71d27, openrc tries to load
modules twice which have been defined in /etc/conf.d/modules via modules=
variable when /bin/sh points to dash shell.
The reason is that when the "modules-load" service was merged into "modules"
service, the "modules" variable name got used in both, load_modules()
function and in Linux_modules() function which both get called when modules
service is started. Although "modules" variable is marked as local in
load_modules(), dash simply ignores this.

Avoid the issue by renaming "modules" variable to "_modules" in
load_modules() function.

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>