### PR TITLE
link to the section of the docs explaining env vars

### DIFF
--- a/service-script-guide.md
+++ b/service-script-guide.md
@@ -123,7 +123,11 @@ command_args=
 pidfile=
 ```
 
-Thus the 'smallest' service scripts can be half a dozen lines long
+Thus the 'smallest' service scripts can be half a dozen lines long.
+
+## Use conf.d to specify default environment variables
+
+See: https://github.com/OpenRC/openrc/blob/master/user-guide.md#the-magic-of-confd
 
 ## Don't write your own start/stop functions
 


### PR DESCRIPTION
This way if someone lands on this page and searches for "env" they will not be sorely disappointed.

Fixes https://github.com/OpenRC/openrc/issues/420