### PR TITLE
on_ac_power: support multiple power_supply devices in sysfs

### DIFF
--- a/scripts/on_ac_power
+++ b/scripts/on_ac_power
@@ -18,9 +18,10 @@ if [ -f /proc/acpi/ac_adapter/*/state ]; then
 		"state:"*"off-line") exit 128;;
 		esac
 	done
-elif [ -f /sys/class/power_supply/*/online ]; then
-	cat /sys/class/power_supply/*/online | while read line; do
-		[ "${line}" = 0 ] && exit 128
+elif [ -d /sys/class/power_supply ]; then
+	for dir in /sys/class/power_supply/*/; do
+		[ "$(cat "${dir}/type")" != "Mains" ] && continue
+		[ "$(cat "${dir}/online")" = 0 ] && exit 128
 	done
 elif [ -f /proc/pmu/info ]; then
 	cat /proc/pmu/info | while read line; do


### PR DESCRIPTION
Newer devices have multiple power_supply devices in sysfs:

```
$ grep ^ /sys/class/power_supply/*/type
/sys/class/power_supply/AC/type:Mains
/sys/class/power_supply/BAT0/type:Battery
/sys/class/power_supply/ucsi-source-psy-USBC000:001/type:USB
/sys/class/power_supply/ucsi-source-psy-USBC000:002/type:USB
```

There are two "USB" Type-C ports than can supply power and both are
aggregated into the "Mains" power supply by the firmware. The "Battery"
also counts as a power supply, but is missing the online attribute.

The -f check with a wildcard pattern results in an error, when multiple
devices are present:

```
/lib/rc/bin/on_ac_power: line 21: [: too many arguments
```

When the power_supply class is registered, check for a "Mains" device.

Signed-off-by: Sven Wegener <sven.wegener@stealer.net>