### PR TITLE
Remove references to "experimental".

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -104,8 +104,6 @@ supervisor=s6.
 or set
 supervisor=supervise-daemon
 to use supervise-daemon.
-Note that supervise-daemon is still in early development, so it is
-considered experimental.
 .It Ar s6_service_path
 The path to the s6 service directory if you are monitoring this service
 with S6. The default is /var/svc.d/${RC_SVCNAME}.

--- a/src/rc/supervise-daemon.c
+++ b/src/rc/supervise-daemon.c
@@ -1,6 +1,6 @@
 /*
  * supervise-daemon
- * This is an experimental supervisor for daemons.
+ * This is a supervisor for daemons.
  * It will start a deamon and make sure it restarts if it crashes.
  */
 


### PR DESCRIPTION
I believe supervise-daemon may now no longer be considered "in early development" or "experimental".

Remove reference to "experimental" supervise-daemon from openrc-run man page (man/openrc-run.8).

Remove "experimental" from src/rc/supervise-daemon.c comment.