### PR TITLE
Implement OOM score adjustment

### DIFF
--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -116,10 +116,12 @@
 
 # Some daemons are started and stopped via start-stop-daemon.
 # We can set some things on a per service basis, like the nicelevel.
-#SSD_NICELEVEL="-19"
+#SSD_NICELEVEL="0"
 # Or the ionice level. The format is class[:data] , just like the
 # --ionice start-stop-daemon parameter.
-#SSD_IONICELEVEL="2:2"
+#SSD_IONICELEVEL="0:0"
+# Or the OOM score adjustment.
+#SSD_OOMSCOREADJ="0"
 
 # Pass ulimit parameters
 # If you are using bash in POSIX mode for your shell, note that the

--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -128,6 +128,8 @@ Class can be 0 for none, 1 for real time, 2 for best effort and 3 for idle.
 Data can be from 0 to 7 inclusive.
 .It Fl N , -nicelevel Ar level
 Modifies the scheduling priority of the daemon.
+.It Fl -oom-score-adj Ar adj
+Modifies the OOM score adjustment of the daemon.
 .It Fl 1 , -stdout Ar logfile
 Redirect the standard output of the process to logfile when started with
 .Fl background .
@@ -185,6 +187,10 @@ option takes precedence.
 .Pp
 .Va SSD_NICELEVEL
 can also set the scheduling priority of the daemon, but the command line
+option takes precedence.
+.Pp
+.Va SSD_OOMSCOREADJ
+can also set the OOM score adjustment of the daemon, but the command line
 option takes precedence.
 .Pp
 .Va SSD_STARTWAIT

--- a/man/supervise-daemon.8
+++ b/man/supervise-daemon.8
@@ -37,6 +37,8 @@ servicename
 .Ar count
 .Fl N , -nicelevel
 .Ar level
+.Fl -oom-score-adj
+.Ar adj
 .Fl p , -pidfile
 .Ar supervisorpidfile
 .Fl P , -respawn-period
@@ -129,6 +131,8 @@ Sets a path for the supervisor's pid file. Note that this is not the pid
 file of the process that is being supervised.
 .It Fl N , -nicelevel Ar level
 Modifies the scheduling priority of the daemon.
+.It Fl -oom-score-adj Ar adj
+Modifies the OOM score adjustment of the daemon.
 .It Fl P , -respawn-period Ar seconds
 Sets the length of a respawn period. See the
 description of --respawn-max for more information.
@@ -162,6 +166,10 @@ option takes precedence.
 .Pp
 .Va SSD_NICELEVEL
 can also set the scheduling priority of the daemon, but the command line
+option takes precedence.
+.Pp
+.Va SSD_OOMSCOREADJ
+can also set the OOM score adjustment of the daemon, but the command line
 option takes precedence.
 .Sh NOTE
 .Nm


### PR DESCRIPTION
This PR adds a new **`--oom-score-adj`** option to `start-stop-daemon` and `supervise-daemon` to complement the existing `--nicelevel` and `--ionice` options. Often it is advantageous to depress the OOM score of critical system services so that the kernel's OOM killer will prefer to kill more "disposable" processes in OOM scenarios. SSD and SD previously lacked a clean way to adjust the OOM scores of the daemons they start. With this patchset, now the `oom_score_adj` of launched daemons can be specified either by the new command-line option or by a new `SSD_OOMSCOREADJ` environment variable, which is akin to `SSD_NICELEVEL` and `SSD_IONICELEVEL`.

**Note:** While crafting this enhancement, I noticed that `supervise-daemon` was missing support for the `SSD_IONICELEVEL` environment variable, as though it had been overlooked when such support was added to `start-stop-daemon`, so I took the opportunity to fill in the missing implementation (in a separate commit, which precedes the commit that holds the real meat of this PR).