### PR TITLE
Move .so files from /usr to /

### DIFF
--- a/mk/sys.mk
+++ b/mk/sys.mk
@@ -50,7 +50,7 @@ INCMODE?=		0644
 _LIBNAME_SH=		case `readlink /lib` in /lib64|lib64) echo "lib64";; *) echo "lib";; esac
 _LIBNAME:=		$(shell ${_LIBNAME_SH})
 LIBNAME?=		${_LIBNAME}
-LIBDIR?=		${UPREFIX}/${LIBNAME}
+LIBDIR?=		${PREFIX}/${LIBNAME}
 LIBMODE?=		0644
 
 LIBEXECDIR?=		${PREFIX}/libexec/rc


### PR DESCRIPTION
This will move `libeinfo.so.1` and `librc.so.1` from `/usr` to `/` so that `openrc-init` can be used before mounting `/usr`.