### PR TITLE
Fix undeclared UT_LINESIZE on musl 1.2

### DIFF
--- a/src/rc/broadcast.c
+++ b/src/rc/broadcast.c
@@ -22,6 +22,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <utmp.h>
 #include <utmpx.h>
 #include <pwd.h>
 #include <fcntl.h>


### PR DESCRIPTION
Fix the following error:

	broadcast.c:41:21: error: '__UT_LINESIZE' undeclared (first use in this function); did you mean 'UT_LINESIZE'?
	 #define UT_LINESIZE __UT_LINESIZE
                          ^~~~~~~~~~

Constant UT_LINESIZE is defined in <utmp.h> provided by musl.