### PR TITLE
rc-mount: make timeout invocation compatible with busybox timeout

### DIFF
--- a/sh/rc-mount.sh
+++ b/sh/rc-mount.sh
@@ -48,7 +48,7 @@ do_unmount()
 		retry=4 # Effectively TERM, sleep 1, TERM, sleep 1, KILL, sleep 1
 		while ! LC_ALL=C $cmd "$mnt" 2>/dev/null; do
 			if command -v fuser >/dev/null 2>&1; then
-				pids="$(timeout -k 10 -s KILL "${rc_fuser_timeout:-60}" \
+				pids="$(timeout -s KILL "${rc_fuser_timeout:-60}" \
 					fuser $f_opts "$mnt" 2>/dev/null)"
 			fi
 			case " $pids " in


### PR DESCRIPTION
Busybox timeout does not support the `-k` flag. As such, invoking fuser
from do_unmount never worked without this patch. This went unnoticed as
standard error is redirected to /dev/null. This patch fixes this by
simply removing the incompatible `-k` flag.

[Ariadne: the `-k` is redundant anyway, since we are sending the KILL
 signal to begin with.]