### PR TITLE
force root be rw before localmount

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -13,9 +13,9 @@ description="Mounts disks and swap according to /etc/fstab."
 
 depend()
 {
-	need fsck
-	use lvm modules root
-	after clock lvm modules root
+	need fsck root
+	use lvm modules
+	after clock lvm modules
 	keyword -docker -jail -lxc -prefix -systemd-nspawn -vserver
 }
 


### PR DESCRIPTION
The service that pulls in root remount is mtab which Alpine doesn't need/use.

[Ariadne: proposed upstream per IRC discussion with WilliamH].