### PR TITLE
call /sbin/mkmntdirs in localmount OpenRC service

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -21,6 +21,8 @@ depend()
 
 start()
 {
+	[ -x /sbin/mkmntdirs ] && mkmntdirs
+
 	# Mount local filesystems in /etc/fstab.
 	# The types variable must start with no, and must be a type
 	local critical= types="noproc" x= no_netdev= rc=


### PR DESCRIPTION
[Ariadne: proposed for inclusion upstream per IRC discussion with WilliamH.]