### PR TITLE
Don't force service dependency cache regeneration on every boot

### DIFF
--- a/src/rc/rc.c
+++ b/src/rc/rc.c
@@ -497,7 +497,7 @@ do_sysinit()
 	if ((sys = rc_sys()))
 		setenv("RC_SYS", sys, 1);
 	/* force an update of the dependency tree */
-	if ((main_deptree = _rc_deptree_load(1, NULL)) == NULL)
+	if ((main_deptree = _rc_deptree_load(0, NULL)) == NULL)
 		eerrorx("failed to load deptree");
 }
 


### PR DESCRIPTION
Avoid cache regeneration on every boot, cache will still be regenerated if needed. See #455 for discussion.