### PR TITLE
checkpath: fix allocation size of string buffer

### DIFF
--- a/src/rc/checkpath.c
+++ b/src/rc/checkpath.c
@@ -151,7 +151,7 @@ static char *clean_path(char *path)
 	char *ch;
 	char *ch2;
 	char *str;
-	str = xmalloc(strlen(path));
+	str = xmalloc(strlen(path) + 1);
 	ch = path;
 	ch2 = str;
 	while (true) {


### PR DESCRIPTION
strlen's return value isn't enough to be used
directly for (x)malloc; it doesn't include
the null byte at the end of the string.

Fixes: #459
Reported-by: Gary E. Miller
X-Gentoo-Bug: https://bugs.gentoo.org/816900
Signed-off-by: Sam James <sam@gentoo.org>