### PR TITLE
Gentoo CI: initial implementation

### DIFF
--- a/.github/workflows/ci-gentoo.yaml
+++ b/.github/workflows/ci-gentoo.yaml
@@ -1,0 +1,101 @@
+name: ci_gentoo
+
+on: [push, pull_request]
+
+jobs:
+
+  glibc:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:latest
+    steps:
+      - name: Sync portage tree
+        run: emerge-webrsync
+      - name: Install git
+        run: emerge -v dev-vcs/git
+      - name: Allow portage build latest master
+        run: echo 'sys-apps/openrc **' > /etc/portage/package.accept_keywords
+      - name: Build
+        run: emerge -v sys-apps/openrc
+        env:
+          EGIT_OVERRIDE_REPO_OPENRC_OPENRC: ${{ github.server_url }}/${{ github.repository }}.git
+          EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC: ${{ github.head_ref }}
+
+  musl:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:musl
+    steps:
+      - name: Sync portage tree
+        run: emerge-webrsync
+      - name: Install git
+        run: emerge -v dev-vcs/git
+      - name: Allow portage build latest master
+        run: echo 'sys-apps/openrc **' > /etc/portage/package.accept_keywords
+      - name: Build
+        run: emerge -v sys-apps/openrc
+        env:
+          EGIT_OVERRIDE_REPO_OPENRC_OPENRC: ${{ github.server_url }}/${{ github.repository }}.git
+          EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC: ${{ github.head_ref }}
+
+  hardened-glibc:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:hardened
+    steps:
+      - name: Sync portage tree
+        run: emerge-webrsync
+      - name: Install git
+        run: emerge -v dev-vcs/git
+      - name: Allow portage build latest master
+        run: echo 'sys-apps/openrc **' > /etc/portage/package.accept_keywords
+      - name: Build
+        run: emerge -v sys-apps/openrc
+        env:
+          EGIT_OVERRIDE_REPO_OPENRC_OPENRC: ${{ github.server_url }}/${{ github.repository }}.git
+          EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC: ${{ github.head_ref }}
+
+  hardened-musl:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:musl-hardened
+    steps:
+      - name: Sync portage tree
+        run: emerge-webrsync
+      - name: Install git
+        run: emerge -v dev-vcs/git
+      - name: Allow portage build latest master
+        run: echo 'sys-apps/openrc **' > /etc/portage/package.accept_keywords
+      - name: Build
+        run: emerge -v sys-apps/openrc
+        env:
+          EGIT_OVERRIDE_REPO_OPENRC_OPENRC: ${{ github.server_url }}/${{ github.repository }}.git
+          EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC: ${{ github.head_ref }}
+
+  nomultilib-glibc:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:nomultilib
+    steps:
+      - name: Sync portage tree
+        run: emerge-webrsync
+      - name: Install git
+        run: emerge -v dev-vcs/git
+      - name: Allow portage build latest master
+        run: echo 'sys-apps/openrc **' > /etc/portage/package.accept_keywords
+      - name: Build
+        run: emerge -v sys-apps/openrc
+        env:
+          EGIT_OVERRIDE_REPO_OPENRC_OPENRC: ${{ github.server_url }}/${{ github.repository }}.git
+          EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC: ${{ github.head_ref }}
+
+  hardened-nomultilib-glibc:
+    runs-on: ubuntu-latest
+    container: gentoo/stage3:hardened-nomultilib
+    steps:
+      - name: Sync portage tree
+        run: emerge-webrsync
+      - name: Install git
+        run: emerge -v dev-vcs/git
+      - name: Allow portage build latest master
+        run: echo 'sys-apps/openrc **' > /etc/portage/package.accept_keywords
+      - name: Build
+        run: emerge -v sys-apps/openrc
+        env:
+          EGIT_OVERRIDE_REPO_OPENRC_OPENRC: ${{ github.server_url }}/${{ github.repository }}.git
+          EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC: ${{ github.head_ref }}


### PR DESCRIPTION
This PR implements CI based on official [Gentoo docker distribution](https://github.com/gentoo/gentoo-docker-images).
Gentoo project already have [internal CI](https://wiki.gentoo.org/wiki/Project:Repository_mirror_and_CI), but AFAIK it's not running against pull requests in this repo. So I thought you may find it useful :)

Basically, this CI uses emerge sys-apps/openrc-9999 and overrides 2 variables pointing to repository and branch (`EGIT_OVERRIDE_REPO_OPENRC_OPENRC`, `EGIT_OVERRIDE_BRANCH_OPENRC_OPENRC`)

Currently, it builds against the following targets using GCC:
- glibc
- musl
- hardened-glibc
- hardened-musl
- nomultilib-glibc
- hardened-nomultilib-glibc

Building against `clang` also can be implemented, but of course it'll increase CI time drastically (now it builds just in 5-7 minutes).
Building with SELinux can't be implemented due to [incompatibility](https://serverfault.com/questions/757606/how-to-enable-selinux-inside-of-a-centos-docker-container) in containers.