### PR TITLE
Added missing comma in openrc/src/rc

### DIFF
--- a/src/rc/rc.c
+++ b/src/rc/rc.c
@@ -66,7 +66,7 @@ const struct option longopts[] = {
 };
 const char * const longopts_help[] = {
 	"do not stop any services",
-	"override the next runlevel to change into\n"
+	"override the next runlevel to change into\n",
 	"when leaving single user or boot runlevels",
 	"runs the service specified with the rest\nof the arguments",
 	"output the RC system type, if any",


### PR DESCRIPTION
Clang was failing with:
```
/zroot/jenkins/workspace/update_ghsotbsd-13_poudriere_jail/sbin/openrc/../../contrib/openrc/src/rc/rc.c:70:2: error: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma? [-Werror,-Wstring-concatenation]
        "when leaving single user or boot runlevels",
        ^
/zroot/jenkins/workspace/update_ghsotbsd-13_poudriere_jail/sbin/openrc/../../contrib/openrc/src/rc/rc.c:69:2: note: place parentheses around the string literal to silence warning
        "override the next runlevel to change into\n"
        ^
```