### PR TITLE
net-online: add missing sleep 1 in ping loop

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -68,6 +68,7 @@ start ()
 			ping -c 1 $ping_test_host > /dev/null 2>&1
 			rc=$?
 			[ $rc -eq 0 ] && break
+			sleep 1
 			: $((timeout -= 1))
 		done
 	fi


### PR DESCRIPTION
Currently the ping loop instantly times out because timeout is decremented by 1 without actually going to sleep.