### PR TITLE
src/rc/rc-status: fix 'started' output (-Wformat)

### DIFF
--- a/src/rc/rc-status.c
+++ b/src/rc/rc-status.c
@@ -130,12 +130,12 @@ static char *get_uptime(const char *service)
 			if (diff_days > 0)
 				xasprintf(&uptime,
 						"%"PRId64" day(s) %02"PRId64":%02"PRId64":%02"PRId64" (%s)",
-						diff_days, diff_hours, diff_mins, diff_secs,
+						(long long) diff_days, (long long) diff_hours, (long long) diff_mins, (long long) diff_secs,
 						start_count);
 			else
 				xasprintf(&uptime,
 						"%02"PRId64":%02"PRId64":%02"PRId64" (%s)",
-						diff_hours, diff_mins, diff_secs, start_count);
+						(long long) diff_hours, (long long) diff_mins, (long long) diff_secs, start_count);
 		}
 	}
 	return uptime;


### PR DESCRIPTION
On 32-bit platforms (e.g. HPPA), GCC warns with:
```
../src/rc/rc-status.c:137:49: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 5 has type ‘time_t’ {aka ‘long int’} [-Wformat=]
  137 |                                                 "%02"PRId64":%02"PRId64":%02"PRId64" (%s)",
      |                                                 ^~~~~
  138 |                                                 diff_hours, diff_mins, diff_secs, start_count);
      |                                                                        ~~~~~~~~~
      |                                                                        |
      |                                                                        time_t {aka long int}
```

We expect the output to be 64-bit but time_t isn't always wide enough, so
let's cast to long long which is guaranteed to be.

Fixes: 25d5de8fd9698fed0fdbbd8949fd4089602b796d
See: https://forums.gentoo.org/viewtopic-t-1146117.html
Signed-off-by: Sam James <sam@gentoo.org>