### PR TITLE
Small format improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,9 +14,9 @@ fs = import('fs')
 audit_dep = dependency('audit', required : get_option('audit'))
 if audit_dep.found()
   cc_audit_flags = '-DHAVE_AUDIT'
-  else
+else
   cc_audit_flags = []
-  endif
+endif
 
 if get_option('branding') != ''
   cc_branding_flags = '-DBRANDING=' + get_option('branding')
@@ -61,7 +61,7 @@ endif
 
 if not pam_dep.found() and get_option('pam')
   error('Pam was requested but could not be located')
-  endif
+endif
 
 cap_dep = dependency('libcap', version: '>=2.33', required : get_option('capabilities'))
 if cap_dep.found()
@@ -154,7 +154,7 @@ elif os == 'FreeBSD'
   cc_os_flags = ['-D_BSD_SOURCE']
 elif os == 'GNU'
   cc_os_flags = ['-D_DEFAULT_SOURCE', '-DMAXPATHLEN=4096', '-DPATH_MAX=4096']
-  endif
+endif
 
 # Try and use some good cc flags if we're building from git. We don't use
 # -pedantic as it will warn about our perfectly valid use of %m in our logger.

--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -38,10 +38,6 @@ ssd_start()
 		service_inactive && _inactive=true
 		mark_service_inactive
 	fi
-	[ -n "$output_logger" ] &&
-		output_logger_arg="--stdout-logger \"$output_logger\""
-	[ -n "$error_logger" ] &&
-		error_logger_arg="--stderr-logger \"$error_logger\""
 	#the eval call is necessary for cases like:
 	# command_args="this \"is a\" test"
 	# to work properly.
@@ -51,8 +47,8 @@ ssd_start()
 		${directory:+--chdir} $directory \
 		${output_log+--stdout} $output_log \
 		${error_log+--stderr} $error_log \
-		${output_logger_arg} \
-		${error_logger_arg} \
+		${output_logger:+--stdout-logger} "$output_logger" \
+		${error_logger:+--stderr-logger} "$error_logger" \
 		${capabilities+--capabilities} "$capabilities" \
 		${secbits:+--secbits} "$secbits" \
 		${no_new_privs:+--no-new-privs} \


### PR DESCRIPTION
Fix indentation in the meson.build file.
Use consistent args passing in start-stop-daemon. 