### PR TITLE
Add securebits and No New Privs flags support for Linux

### DIFF
--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -168,6 +168,8 @@ The format is the same as in cap_iab(3).
 Set the security-bits for the program.
 The numeric value of the security-bits can be found in <sys/secbits.h> header file.
 The format is the same as in strtoul(3).
+.It Fl -no-new-privs
+Set the No New Privs flag for the program. See PR_SET_NO_NEW_PRIVS prctl(2).
 .It Fl w , -wait Ar milliseconds
 Wait
 .Ar milliseconds

--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -164,6 +164,10 @@ log it or send it to another location.
 .It Fl -capabilities Ar cap-list
 Start the daemon with the listed inheritable, ambient and bounding capabilities.
 The format is the same as in cap_iab(3).
+.It Fl -secbits Ar sec-bits
+Set the security-bits for the program.
+The numeric value of the security-bits can be found in <sys/secbits.h> header file.
+The format is the same as in strtoul(3).
 .It Fl w , -wait Ar milliseconds
 Wait
 .Ar milliseconds

--- a/man/supervise-daemon.8
+++ b/man/supervise-daemon.8
@@ -165,6 +165,8 @@ The format is the same as in cap_iab(3).
 Set the security-bits for the program.
 The numeric value of the security-bits can be found in <sys/secbits.h> header file.
 The format is the same as in strtoul(3).
+.It Fl -no-new-privs
+Set the No New Privs flag for the program. See PR_SET_NO_NEW_PRIVS prctl(2).
 .El
 .Sh ENVIRONMENT
 .Va SSD_IONICELEVEL

--- a/man/supervise-daemon.8
+++ b/man/supervise-daemon.8
@@ -161,6 +161,10 @@ but with the standard error output.
 .It Fl -capabilities Ar cap-list
 Start the daemon with the listed inheritable, ambient and bounding capabilities.
 The format is the same as in cap_iab(3).
+.It Fl -secbits Ar sec-bits
+Set the security-bits for the program.
+The numeric value of the security-bits can be found in <sys/secbits.h> header file.
+The format is the same as in strtoul(3).
 .El
 .Sh ENVIRONMENT
 .Va SSD_IONICELEVEL

--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -54,6 +54,7 @@ ssd_start()
 		${output_logger_arg} \
 		${error_logger_arg} \
 		${capabilities+--capabilities} "$capabilities" \
+		${secbits:+--secbits} "$secbits" \
 		${procname:+--name} $procname \
 		${pidfile:+--pidfile} $pidfile \
 		${command_user+--user} $command_user \

--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -55,6 +55,7 @@ ssd_start()
 		${error_logger_arg} \
 		${capabilities+--capabilities} "$capabilities" \
 		${secbits:+--secbits} "$secbits" \
+		${no_new_privs:+--no-new-privs} \
 		${procname:+--name} $procname \
 		${pidfile:+--pidfile} $pidfile \
 		${command_user+--user} $command_user \

--- a/sh/supervise-daemon.sh
+++ b/sh/supervise-daemon.sh
@@ -37,6 +37,7 @@ supervise_start()
 		${healthcheck_delay:+--healthcheck-delay} $healthcheck_delay \
 		${healthcheck_timer:+--healthcheck-timer} $healthcheck_timer \
 		${capabilities+--capabilities} "$capabilities" \
+		${secbits:+--secbits} "$secbits" \
 		${command_user+--user} $command_user \
 		${umask+--umask} $umask \
 		${supervise_daemon_args:-${start_stop_daemon_args}} \

--- a/sh/supervise-daemon.sh
+++ b/sh/supervise-daemon.sh
@@ -38,6 +38,7 @@ supervise_start()
 		${healthcheck_timer:+--healthcheck-timer} $healthcheck_timer \
 		${capabilities+--capabilities} "$capabilities" \
 		${secbits:+--secbits} "$secbits" \
+		${no_new_privs:+--no_new_privs} \
 		${command_user+--user} $command_user \
 		${umask+--umask} $umask \
 		${supervise_daemon_args:-${start_stop_daemon_args}} \


### PR DESCRIPTION
Add the securebits of the capabilities feature and the No New Privs flag for Linux. This should increase the security of the running daemon, if the options are used.

# Test
This is how I tested it if it works:

## securebits
I execute the following command as `root` with the securebit `SECBIT_NOROOT`:
```sh
RC_SVCNAME=test ./supervise-daemon test --start --capabilities ^cap_chown,^cap_net_bind_service --secbits 0x01 /usr/bin/sleep 60
```
And checked if the permitted set is the same as the inheritable set:
```sh
$ cat /proc/14757/status
[...]
CapInh:	0000000000000401
CapPrm:	0000000000000401
[...]
```

## No New Privs
I execute the following command as `root` with the No New Privs flag:
```sh
 RC_SVCNAME=test ./supervise-daemon test --start --no-new-privs /usr/bin/sleep 60
```
And checked if the No New Privs flag is set:
```sh
$ cat /proc/15168/status
[...]
NoNewPrivs:	1
[...]
```
