### PR TITLE
rc-misc.c: Allocate memory for 'file'

### DIFF
--- a/src/rc/rc-misc.c
+++ b/src/rc/rc-misc.c
@@ -362,7 +362,7 @@ RC_DEPTREE * _rc_deptree_load(int force, int *regen)
 	int serrno = errno;
 	int merrno;
 	time_t t;
-	char *file = NULL;
+	char file[PATH_MAX];
 	struct stat st;
 	struct utimbuf ut;
 	FILE *fp;


### PR DESCRIPTION
This is a partial revert of commit 8e02406d ("rc-misc.c: remove
references to PATH_MAX"), which changed 'file' to a null pointer with no
associated storage.

````
../openrc-0.44.10/src/rc/rc-misc.c: In function ‘_rc_deptree_load’:
../openrc-0.44.10/src/rc/rc-misc.c:392:33: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
392 |                                 eerror("Clock skew detected with `%s'", file);
    |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````

Fixes: 8e02406d ("rc-misc.c: remove references to PATH_MAX")