### PR TITLE
init.d/devfs: default mount /dev noexec

### DIFF
--- a/init.d/devfs.in
+++ b/init.d/devfs.in
@@ -24,8 +24,9 @@ mount_dev()
 	action=--mount
 	conf_d_dir="${RC_SERVICE%/*/*}/conf.d"
 	msg=Mounting
-	# Some devices require exec, Bug #92921
-	mountopts="exec,nosuid,mode=0755"
+	# Some devices require exec, https://bugs.gentoo.org/92921
+	# Users with such requirements can use an fstab entry for /dev
+	mountopts="noexec,nosuid,mode=0755"
 	if yesno ${skip_mount_dev:-no} ; then
 		einfo "/dev will not be mounted due to user request"
 		return 0


### PR DESCRIPTION
Since I read this https://www.phoronix.com/scan.php?page=news_item&px=Linux-5.17-Devtmpfs-Change I've been running Alpinelinux with /dev mounted noexec without issues.