### PR TITLE
init.d/bootmisc.in: prevent error due to nonexistant file

### DIFF
--- a/init.d/bootmisc.in
+++ b/init.d/bootmisc.in
@@ -226,7 +226,7 @@ start()
 			case "$RC_SYS" in
 				VSERVER|OPENVZ|LXC|SYSTEMD-NSPAWN) ;;
 				*)
-					if yesno ${previous_dmesg:-no}; then
+					if yesno ${previous_dmesg:-no} && [ -e /var/log/dmesg ]; then
 						mv /var/log/dmesg /var/log/dmesg.old
 					fi
 					dmesg > /var/log/dmesg


### PR DESCRIPTION
During boot if the "previous_dmesg" setting is enabled in
/etc/conf.d/bootmisc then during the 1st boot of a machine the
bootmisc init.d script will attempt to move a nonexistant dmesg
file, so generating an error on the console.

Modify the script to only move an existing file.