### PR TITLE
Add newline for `want`

### DIFF
--- a/service-script-guide.md
+++ b/service-script-guide.md
@@ -80,7 +80,8 @@ depend() {
 
 `use` is a soft dependency - if dns, logger or netmount is in this runlevel 
 	start it before, but we don't care if it's not in this runlevel.
-	`want` is between need and use - try to start coolservice if it is
+	
+`want` is between need and use - try to start coolservice if it is
 	installed on the system, regardless of whether it is in the
 	runlevel, but we don't care if it starts.
 


### PR DESCRIPTION
The comment block for `want` seemed to be unintentionally part of the `use` block. Added a newline so `want` will have its own section.