### PR TITLE
Add clangd support for development

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: builddir/


### PR DESCRIPTION
Add a clangd config file to the default build directory, so that clangd can find the `compile_commands.json`. 