### PR TITLE
init.d/seedrng.in: fix rc_yesno typo

### DIFF
--- a/init.d/seedrng.in
+++ b/init.d/seedrng.in
@@ -25,7 +25,7 @@ seedrng_options()
 		echo "--lock-file \"${lock_file}\""
 	[ -n "${seed_dir}" ] &&
 		echo "--seed-dir \"${seed_dir}\""
-	rc_yesno "${skip_credit}" &&
+	yesno "${skip_credit}" &&
 		echo "--skip-credit"
 }
 


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>