### PR TITLE
binfmt: ignore empty lines (#492)

### DIFF
--- a/sh/binfmt.sh.in
+++ b/sh/binfmt.sh.in
@@ -27,6 +27,7 @@ apply_file() {
 		case $line in
 			\#*) continue ;;
 			\;*) continue ;;
+			'')  continue ;;
 		esac
 
 		local reg=${line#*:}


### PR DESCRIPTION
This Pull Request closes #492.

According to <https://freedesktop.org/software/systemd/man/binfmt.d.html#Configuration%20Format>:

> *Empty lines* and lines beginning with ";" and "#" are ignored.
> Note that this means you may not use those symbols as the delimiter in binary format rules.
