### PR TITLE
Coverity needs secrets

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,8 +9,26 @@ on:
     branches: [master]
 
 jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      HAS_SCAN_EMAIL: ${{ steps.check.output.HAS_SCAN_EMAIL }}
+      HAS_SCAN_TOKEN: ${{ steps.check.output.HAS_SCAN_TOKEN }}
+    steps:
+      - run: >
+          echo "::set-output name=HAS_SCAN_EMAIL::${{ env.COVERITY_SCAN_EMAIL != '' }}";
+          echo "::set-output name=HAS_SCAN_TOKEN::${{ env.COVERITY_SCAN_TOKEN != '' }}";
+        id: check
+        env:
+          COVERITY_SCAN_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
   coverity:
     runs-on: ubuntu-latest
+    needs: ["secrets"]
+    if: >
+      needs.secrets.outputs.HAS_SCAN_EMAIL == 'true' &&
+      needs.secrets.outputs.HAS_SCAN_TOKEN == 'true'
     steps:
     - uses: actions/checkout@v2
     - run: sudo apt-get update -q


### PR DESCRIPTION
Every time I fetch a new `master` from this repository, the coverity check fails like this:
https://github.com/jsoref/openrc/runs/6190299997?check_suite_focus=true

It is possible to configure a workflow to look before it leaps, like this:
https://github.com/jsoref/openrc/actions/runs/2232136346

For a bit of information about how this works, here's the documentation:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets

The version of the flow I'm using is the longer-winded version. It is possible to do the work in the same job, but there are 5 steps that should be skipped, and it's a lot cleaner to skip a job w/ 5 steps than to add conditions to skip each of 5 steps.