### PR TITLE
init.d/root: add support for 'shared' fstab option on /

### DIFF
--- a/init.d/root.in
+++ b/init.d/root.in
@@ -20,7 +20,8 @@ depend()
 
 start()
 {
-	case ",$(fstabinfo -o /)," in
+	local root_opts=",$(fstabinfo -o /),"
+	case "$root_opts" in
 		*,ro,*)
 		;;
 		*)
@@ -42,6 +43,21 @@ start()
 					rm -f /fastboot /forcefsck
 				fi
 			fi
+		;;
+	esac
+
+	case "$root_opts" in
+		*,shared,*|*,rshared,*)
+			ebegin "Making root filesystem shared"
+			case "$RC_UNAME" in
+				Linux)
+					mount --make-rshared /
+				;;
+				*)
+					ewarn "Ignoring 'shared' option for / on non-linux"
+				;;
+			esac
+			eend $? "Root filesystem could not be mounted read/write"
 		;;
 	esac
 


### PR DESCRIPTION
containers on linux might require filesystems to be mounted with
different propagation than the kernel default of 'private':
by setting 'shared' in fstab for / options, one can now make the
fs hierarchy shared.

Note we use 'rshared' to make other existing mounts shared as well
because the setting is contagious and it seemed more logical to
behave as if the setting was set on / immediately (and thus inherited
by other mounts)

This fixes #525.