### PR TITLE
fix quoting of loggers in start-stop-daemon

### DIFF
--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -47,8 +47,8 @@ ssd_start()
 		${directory:+--chdir} $directory \
 		${output_log+--stdout} $output_log \
 		${error_log+--stderr} $error_log \
-		${output_logger:+--stdout-logger} "$output_logger" \
-		${error_logger:+--stderr-logger} "$error_logger" \
+		${output_logger:+--stdout-logger \"$output_logger\"} \
+		${error_logger:+--stderr-logger \"$error_logger\"} \
 		${capabilities+--capabilities} "$capabilities" \
 		${secbits:+--secbits} "$secbits" \
 		${no_new_privs:+--no-new-privs} \


### PR DESCRIPTION
previously broken in 6034866d1c74d5a23eb9f3e0ebf40c9d278aac93
caused *_logger options to be passed unquoted, so
`error_logger="logger -t .."` would pass -t to s-s-d and fail to start
the service.