### PR TITLE
init.d: also remount / with options provided in /etc/fstab

### DIFF
--- a/init.d/root.in
+++ b/init.d/root.in
@@ -48,14 +48,8 @@ start()
 	ebegin "Remounting filesystems"
 	local mountpoint
 	for mountpoint in $(fstabinfo); do
-		case "${mountpoint}" in
-			/)
-			;;
-			/*)
-				mountinfo -q "${mountpoint}" && \
-					fstabinfo --remount "${mountpoint}"
-			;;
-		esac
+		mountinfo -q "${mountpoint}" && \
+			fstabinfo --remount "${mountpoint}"
 	done
 	eend 0
 }


### PR DESCRIPTION
Without this commit, the root OpenRC service remounts all mounted filesystems (except `/`) with the options defined in `/etc/fstab` via `fstabinfo`. It is presently unclear to me why `/` was excluded from remounting in 497ff7ee41168d863971efb52e2ca6b42f765832 and unfortunately neither the commit nor the associated Bugzilla issue [\[1\]][1] provides further information on this.

At Alpine, our initramfs does currently not remount `/` with all options defined in `/etc/fstab` [\[2\]][2]. As part of the discussion on the Alpine side of things we wondered why OpenRC does not remount `/` since this would be
the easier solution for us. For this reason, this commit changes the behavior of the OpenRC root services accordingly to also remount `/` with the options defined in `/etc/fstab`. Would you be interested in including this change upstream?

I've tested this locally and it works fine for my own setup so far.

[1]: https://bugs.gentoo.org/401573
[2]: https://gitlab.alpinelinux.org/alpine/mkinitfs/-/merge_requests/103