### PR TITLE
start-stop-daemon.sh: make command_user work properly

### DIFF
--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -54,7 +54,7 @@ ssd_start()
 		${no_new_privs:+--no-new-privs} \
 		${procname:+--name} $procname \
 		${pidfile:+--pidfile} $pidfile \
-		${command_user+--user} $command_user \
+		${command_user+--chuid} $command_user \
 		${umask+--umask} $umask \
 		$_background $start_stop_daemon_args \
 		-- $command_args $command_args_background


### PR DESCRIPTION
From the openrc-run manpage, the command_user variable has this description: "If the daemon does not support changing to a user id, you can use this to change the user id, and optionally group id,  before start-stop-daemon(8) or supervise-daemon(8) launches the daemon."

My understanding is that start-stop-daemon's --user flag is not what is intended here, but rather --chuid. Prior to this change, I could not make this flag function as intended (i.e. scripts would run as root no matter what username/group combination was entered), and this edit seems to fix it.
