### PR TITLE
openrc: fix help messages

### DIFF
--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -64,8 +64,7 @@ const struct option longopts[] = {
 };
 const char * const longopts_help[] = {
 	"do not stop any services",
-	"override the next runlevel to change into\n",
-	"when leaving single user or boot runlevels",
+	"override the next runlevel to change into\nwhen leaving single user or boot runlevels",
 	"runs the service specified with the rest\nof the arguments",
 	"output the RC system type, if any",
 	longopts_help_COMMON


### PR DESCRIPTION
The two lines seem to both belong to --override, but made into seperate
array elements accidentally, making options after --override and their
help mismatch. This fixes it.