### PR TITLE
start-stop-daemon, supervise-daemon: use closefrom()/close_range()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -192,6 +192,14 @@ if cc.compiles(malloc_attribute_test, name : 'malloc attribute with arguments')
   add_project_arguments('-DHAVE_MALLOC_EXTENDED_ATTRIBUTE', language: 'c')
 endif
 
+if cc.has_function('closefrom', prefix: '#define _GNU_SOURCE\n#include <unistd.h>')
+  add_project_arguments('-DHAVE_CLOSEFROM', language: 'c')
+endif
+if cc.has_function('close_range', prefix: '#define _GNU_SOURCE\n#include <unistd.h>') and \
+    cc.has_header_symbol('unistd.h', 'CLOSE_RANGE_CLOEXEC', prefix: '#define _GNU_SOURCE')
+  add_project_arguments('-DHAVE_CLOSE_RANGE_CLOEXEC', language: 'c')
+endif
+
 incdir = include_directories('src/shared')
 einfo_incdir = include_directories('src/libeinfo')
 rc_incdir = include_directories('src/librc')

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -1105,8 +1105,7 @@ int main(int argc, char **argv)
 			dup2(stderr_fd, STDERR_FILENO);
 
 		for (i = getdtablesize() - 1; i >= 3; --i)
-			if (i != pipefd[1])
-				close(i);
+			close(i);
 
 		if (scheduler != NULL) {
 			int scheduler_index;

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -1104,8 +1104,12 @@ int main(int argc, char **argv)
 				|| rc_yesno(getenv("EINFO_QUIET")))
 			dup2(stderr_fd, STDERR_FILENO);
 
+#ifdef HAVE_CLOSEFROM
+		closefrom(3);
+#else
 		for (i = getdtablesize() - 1; i >= 3; --i)
 			close(i);
+#endif
 
 		if (scheduler != NULL) {
 			int scheduler_index;


### PR DESCRIPTION
On systems with a very large `RLIMIT_NOFILE`, calling `close()` in a loop from 3 to `getdtablesize()` effects an enormous number of system calls. There are better alternatives. Both BSD and Linux have the `closefrom()` system call that closes all file descriptors with indices not less than a specified minimum. Have `start-stop-daemon` call `closefrom()` on systems where it's implemented, falling back to the old loop elsewhere.

Likewise, calling `fcntl(i, F_SETFD, FD_CLOEXEC)` in a loop from 3 to `getdtablesize()` raises a similar performance concern. Linux 5.11 and onward has a `close_range()` system call with a `CLOSE_RANGE_CLOEXEC` flag that sets the `FD_CLOEXEC` flag on all file descriptors in a specified range. Have `supervise-daemon` utilize this feature on systems where it's implemented, falling back to the old loop elsewhere.