### PR TITLE
init.d: don't remount swap in root service

### DIFF
--- a/init.d/root.in
+++ b/init.d/root.in
@@ -48,8 +48,12 @@ start()
 	ebegin "Remounting filesystems"
 	local mountpoint
 	for mountpoint in $(fstabinfo); do
-		mountinfo -q "${mountpoint}" && \
-			fstabinfo --remount "${mountpoint}"
+		case "${mountpoint}" in
+			/*) # Don't remount swap etc.
+				mountinfo -q "${mountpoint}" && \
+					fstabinfo --remount "${mountpoint}"
+			;;
+		esac
 	done
 	eend 0
 }


### PR DESCRIPTION
While [refactoring](https://github.com/OpenRC/openrc/pull/533#discussion_r957050654) the changes proposed in #533 a minor error was introduced were the root service will now attempt to remount swap. This will fail with the error message `mountinfo: 'swap' is not a mountpoint`. I missed this during initial testing since I only tested the refactored version of the proposed change on a system without a swap partition. I added a comment to the code in order to avoid re-introducing this regression in the future.