### PR TITLE
supervise-daemon: don't fallback to start_stop_daemon_args if supervise_daemon_args is set, but empty

### DIFF
--- a/sh/supervise-daemon.sh
+++ b/sh/supervise-daemon.sh
@@ -41,7 +41,7 @@ supervise_start()
 		${no_new_privs:+--no_new_privs} \
 		${command_user+--user} $command_user \
 		${umask+--umask} $umask \
-		${supervise_daemon_args:-${start_stop_daemon_args}} \
+		${supervise_daemon_args-${start_stop_daemon_args}} \
 		$command \
 		-- $command_args $command_args_foreground
 	rc=$?


### PR DESCRIPTION
If supervise_daemon_args is not set *or empty*, it defaults to `start_stop_daemon_args`. This is bad because supervise-daemon doesn't accept the same options as `start-stop-daemon`. So if we set e.g. `start_stop_daemon_args="--wait 50"`, but not `supervise_daemon_args`, and the user adds `supervisor=supervise-daemon` to the corresponding /etc/conf.d/<service> file, the service will fail to start due to unrecognized option "wait".

It would be best to remove this fallback, but that might break some existing scripts that depend on it. So this commit just changes it to use `start_stop_daemon_args` as the default for `supervise_daemon_args` only if `supervise_daemon_args` is not set at all, but not if it's empty.

This at least simplifies workarounds; we can just add `supervise_daemon_args="$supervise_daemon_args"` to init scripts.