### PR TITLE
swclock: Use the same file for both saving and loading

### DIFF
--- a/init.d/swclock.in
+++ b/init.d/swclock.in
@@ -31,6 +31,6 @@ start()
 stop()
 {
 	ebegin "Saving the shutdown time"
-	swclock --save
+	swclock --save @SBINDIR@/openrc-run
 	eend $?
 }


### PR DESCRIPTION
If no path is specified on the command-line when calling `swclock`, it defaults to saving and loading the last shutdown time from a file named `shutdowntime`:
https://github.com/OpenRC/openrc/blob/9380347f042f7d294317f4420b648422817eb75a/src/swclock/swclock.c#L37

I noticed `swclock` wasn't operating as I'd expect on Alpine Linux and went investigating to find that `/etc/init.d/swclock` was calling `swclock` with no path defined when saving the time:

https://github.com/OpenRC/openrc/blob/9380347f042f7d294317f4420b648422817eb75a/init.d/swclock.in#L34

But providing the path of `@SBINDIR@/openrc-run` when loading the time:

https://github.com/OpenRC/openrc/blob/9380347f042f7d294317f4420b648422817eb75a/init.d/swclock.in#L26

Sure enough I found a file named `/run/openrc/shutdowntime` was being created, though on a `tmpfs`, and regardless, not being used when loading the time.

This PR updates `/etc/init.d/swclock` so the same file is used for both - `@SBINDIR@/openrc-run`. I chose this over using the default, as I've noted that systems such as Alpine Linux are placing `shutdowntime` in a location backed by `tmpfs`. 

What I am changing hasn't changed in many many years, so either this has been broken for a long time, or I'm misunderstanding how it works, which is entirely possible, apologies if it is the later, I thought a PR rather than Issue would be more worthwhile in-case I am on the right track! 😄 

Possibly closes https://github.com/OpenRC/openrc/issues/430.
 