### PR TITLE
librc-depend: fix -Wmismatched-dealloc

### DIFF
--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -1074,6 +1074,6 @@ rc_deptree_update(void)
 	}
 
 	rc_stringlist_free(config);
-	rc_deptree_free(deptree);
+	free(deptree);
 	return retval;
 }


### PR DESCRIPTION
Despite this being a 'deptree', it's actually
xmalloc'd in the same function (rc_deptree_update), and so should be free'd, not rc_deptree_free'd,
as rc_deptree_new wasn't used to allocate it.

```
[71/213] Compiling C object src/librc/librc.so.1.p/librc-depend.c.o
../src/librc/librc-depend.c: In function ‘rc_deptree_update’:
../src/librc/librc-depend.c:1077:9: warning: ‘rc_deptree_free’ called on pointer returned from a mismatched allocation function [-Wmismatched-dealloc]
 1077 |         rc_deptree_free(deptree);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/shared/misc.h:29,
                 from ../src/librc/librc.h:57,
                 from ../src/librc/librc-depend.c:21:
In function ‘xmalloc’,
    inlined from ‘rc_deptree_update’ at ../src/librc/librc-depend.c:775:12:
../src/shared/helpers.h:64:23: note: returned from ‘malloc’
   64 |         void *value = malloc(size);
      |                       ^~~~~~~~~~~~
```