### PR TITLE
Fix swclock

### DIFF
--- a/conf.d/meson.build
+++ b/conf.d/meson.build
@@ -7,6 +7,7 @@ conf_common = [
   'localmount',
   'netmount',
   'swap',
+  'swclock',
   ]
 
 conf_net = [

--- a/conf.d/swclock
+++ b/conf.d/swclock
@@ -1,0 +1,6 @@
+# This is the location of the reference file swclock uses to set the
+# system date and time.
+# This is the default path. If you are using it, you do not need to
+# uncomment it. If you are using the default and have /var on its own
+# file system, you need to add the appropriate rc_after setting.
+# swclock_file=/var/lib/misc/openrc-shutdowntime

--- a/init.d/swclock.in
+++ b/init.d/swclock.in
@@ -10,6 +10,7 @@
 # except according to the terms contained in the LICENSE file.
 
 description="Sets the local clock to the mtime of a given file."
+swclock_file="${swclock_file:-/var/lib/misc/openrc-shutdowntime}"
 
 depend()
 {
@@ -22,7 +23,7 @@ depend()
 start()
 {
 	ebegin "Setting the local clock based on last shutdown time"
-	if ! swclock 2> /dev/null; then
+	if ! swclock "${swclock_file}" 2> /dev/null; then
 	swclock --warn @SBINDIR@/openrc-run
 	fi
 	eend $?
@@ -31,6 +32,6 @@ start()
 stop()
 {
 	ebegin "Saving the shutdown time"
-	swclock --save
+	swclock --save "${swclock_file}"
 	eend $?
 }

--- a/src/swclock/swclock.c
+++ b/src/swclock/swclock.c
@@ -34,7 +34,6 @@
 #include "misc.h"
 #include "_usage.h"
 
-#define RC_SHUTDOWNTIME    RC_SVCDIR "/shutdowntime"
 
 const char *applet = NULL;
 const char *extraopts = "file";
@@ -54,7 +53,7 @@ const char *usagestring = NULL;
 int main(int argc, char **argv)
 {
 	int opt, sflag = 0, wflag = 0;
-	const char *file = RC_SHUTDOWNTIME;
+	const char *file = NULL;
 	struct stat sb;
 	struct timeval tv;
 
@@ -75,6 +74,8 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		file = argv[optind++];
+	else
+		eerrorx("swclock: Reference file was not specified");
 
 	if (sflag) {
 		if (stat(file, &sb) == -1) {


### PR DESCRIPTION
This closes #560.
This closes #430.

This moves the default for the swclock reference file to /var/lib and allows this path to be configured.