### PR TITLE
openrc: avoid unnecessary malloc inside sig-handler

### DIFF
--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -382,7 +382,7 @@ static void
 handle_signal(int sig)
 {
 	int serrno = errno;
-	char *signame = NULL;
+	const char *signame = NULL;
 	pid_t pid;
 	RC_PID *pi;
 	int status = 0;
@@ -414,15 +414,15 @@ handle_signal(int sig)
 
 	case SIGINT:
 		if (!signame)
-			xasprintf(&signame, "SIGINT");
+			signame = "SIGINT";
 		/* FALLTHROUGH */
 	case SIGTERM:
 		if (!signame)
-			xasprintf(&signame, "SIGTERM");
+			signame = "SIGTERM";
 		/* FALLTHROUGH */
 	case SIGQUIT:
 		if (!signame)
-			xasprintf(&signame, "SIGQUIT");
+			signame = "SIGQUIT";
 		eerrorx("%s: caught %s, aborting", applet, signame);
 		/* NOTREACHED */
 	case SIGUSR1:


### PR DESCRIPTION
malloc (called by xasprintf) is not async-signal-safe. beside, the string here is constant, so there's no need to malloc it all.

eerrorx isn't async-signal-safe either (due to calling fprintf and exit) but consequence of them are _typically_ not as grave as calling malloc while it's internal state is inconsistent.

Bug: https://github.com/OpenRC/openrc/issues/589