### PR TITLE
swclock: fix codeql warning and upgrade to futimens

### DIFF
--- a/src/swclock/swclock.c
+++ b/src/swclock/swclock.c
@@ -78,14 +78,12 @@ int main(int argc, char **argv)
 		eerrorx("swclock: Reference file was not specified");
 
 	if (sflag) {
-		if (stat(file, &sb) == -1) {
-			opt = open(file, O_WRONLY | O_CREAT, 0644);
-			if (opt == -1)
-				eerrorx("swclock: open: %s", strerror(errno));
-			close(opt);
-		} else
-			if (utime(file, NULL) == -1)
-				eerrorx("swclock: utime: %s", strerror(errno));
+		int fd = open(file, O_WRONLY | O_CREAT, 0644);
+		if (fd == -1)
+			eerrorx("swclock: open: %s", strerror(errno));
+		if (futimens(fd, NULL) == -1)
+			eerrorx("swclock: futimens: %s", strerror(errno));
+		close(fd);
 		return 0;
 	}
 


### PR DESCRIPTION
this was reported by codeql's scan as a TOCTOU bug. while that's true in theory, i don't believe it would've had any practical effect.

a better justification for this change might be the fact that it upgrades from `utime` (which is depreciated by POSIX [0]) to `futimens`.

[0]: https://www.man7.org/linux/man-pages/man3/utime.3p.html#FUTURE_DIRECTIONS