### PR TITLE
openrc, shared: make headers standalone in prep. for clang-tidy

### DIFF
--- a/src/openrc/rc-logger.h
+++ b/src/openrc/rc-logger.h
@@ -13,6 +13,9 @@
 #ifndef RC_LOGGER_H
 #define RC_LOGGER_H
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 extern pid_t rc_logger_pid;
 extern int rc_logger_tty;
 extern bool rc_in_logger;

--- a/src/shared/helpers.h
+++ b/src/shared/helpers.h
@@ -18,6 +18,10 @@
 #ifndef __HELPERS_H__
 #define __HELPERS_H__
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #define ERRX fprintf (stderr, "out of memory\n"); exit (1)
 
 #define UNCONST(a)		((void *)(unsigned long)(const void *)(a))

--- a/src/shared/misc.h
+++ b/src/shared/misc.h
@@ -27,6 +27,7 @@
 #include <unistd.h>
 
 #include "helpers.h"
+#include "rc.h"
 
 #define RC_LEVEL_BOOT           "boot"
 #define RC_LEVEL_DEFAULT        "default"

--- a/src/shared/plugin.h
+++ b/src/shared/plugin.h
@@ -18,6 +18,11 @@
 #ifndef __LIBRC_PLUGIN_H__
 #define __LIBRC_PLUGIN_H__
 
+#include <stdbool.h>
+#include <sys/types.h>
+
+#include "rc.h"
+
 /* A simple flag to say if we're in a plugin process or not.
  * Mainly used in atexit code. */
 extern bool rc_in_plugin;

--- a/src/shared/schedules.h
+++ b/src/shared/schedules.h
@@ -13,6 +13,9 @@
 #ifndef __RC_SCHEDULES_H
 #define __RC_SCHEDULES_H
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 void free_schedulelist(void);
 int parse_signal(const char *applet, const char *sig);
 void parse_schedule(const char *applet, const char *string, int timeout);


### PR DESCRIPTION
clang-tidy evaluates the headers individually, apparently, when invoked
via meson's clang-tidy target, so let's make them standalone by
including what they need.