### PR TITLE
rc: signal safety improvement

### DIFF
--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -117,8 +117,7 @@ clean_failed(void)
 static void
 cleanup(void)
 {
-	RC_PID *p1 = LIST_FIRST(&service_pids);
-	RC_PID *p2;
+	RC_PID *p, *tmp;
 
 	if (!rc_in_logger && !rc_in_plugin &&
 	    applet && (strcmp(applet, "rc") == 0 || strcmp(applet, "openrc") == 0))
@@ -140,16 +139,13 @@ cleanup(void)
 		rc_logger_close();
 	}
 
-	while (p1) {
-		p2 = LIST_NEXT(p1, entries);
-		free(p1);
-		p1 = p2;
+	LIST_FOREACH_SAFE(p, &service_pids, entries, tmp) {
+		LIST_REMOVE(p, entries);
+		free(p);
 	}
-
-	for (p1 = LIST_FIRST(&free_these_pids); p1; /* no-op */) {
-		p2 = LIST_NEXT(p1, entries);
-		free(p1);
-		p1 = p2;
+	LIST_FOREACH_SAFE(p, &free_these_pids, entries, tmp) {
+		LIST_REMOVE(p, entries);
+		free(p);
 	}
 
 	rc_stringlist_free(main_hotplugged_services);


### PR DESCRIPTION
### rc: avoid calling free inside SIGCHLD handler

`free` is not async-signal-safe and calling it inside a signal handler
can have bad effects, as reported in the musl ML:
https://www.openwall.com/lists/musl/2023/01/23/1

the solution:

- keep track of weather remove_pid() is being called from inside a
  signal handler or not.
- if it's inside a signal handler then DO NOT call free - instead put
  that pointer into a "to be freed later" list.
- if it's not inside a signal handler then take the "to be freed later"
  list and free anything in it.

### rc: block SIGCHLD during pid list operations

the pid list will be accessed inside the SIGCHLD signal handler. so we
must ensure SIGCHLD handler doesn't get invoked while the list is at an
inconsistent state making it unsafe to interact with.

### rc: use LIST_FOREACH_SAFE in cleanup()

according to the linux manpage, the "safe" variant may not be available
on all platform. however we bundle our own `queue.h` so this should not
be an issue.

Bug: https://github.com/OpenRC/openrc/issues/589