### PR TITLE
fstabinfo: remove vfork and deal with EINTR

### DIFF
--- a/src/fstabinfo/fstabinfo.c
+++ b/src/fstabinfo/fstabinfo.c
@@ -143,7 +143,7 @@ do_mount(struct ENT *ent, bool remount)
 	err = posix_spawnp(&pid, argv[0], NULL, NULL, argv, environ);
 	if (err)
 		eerrorx("%s: posix_spawnp: %s", applet, strerror(err));
-	waitpid(pid, &status, 0);
+	while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
 	if (WIFEXITED(status))
 		return WEXITSTATUS(status);
 	else


### PR DESCRIPTION
### fstabinfo: replace vfork with posix_spawnp

problem:
* vfork has been removed from POSIX [0].
* clang-tidy flags the `strerror` and `eerror` call inside the vfork-ed
child as undefined behavior.

solution: use posix_spawnp, which is serves similar purpose and is
specified in posix. and as an added bonus, it's also easier to use and
less lines of code.

[0]: https://www.man7.org/linux/man-pages/man2/vfork.2.html#CONFORMING_TO

### fstabinfo: deal with EINTR in waitpid call
