### PR TITLE
openrc-run: remove kludge in restart --no-deps

### DIFF
--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -1041,26 +1041,6 @@ svc_stop(void)
 static void
 svc_restart(void)
 {
-	/* This is hairy and a better way needs to be found I think!
-	 * The issue is this - openvpn need net and dns. net can restart
-	 * dns via resolvconf, so you could have openvpn trying to restart
-	 * dnsmasq which in turn is waiting on net which in turn is waiting
-	 * on dnsmasq.
-	 * The work around is for resolvconf to restart its services with
-	 * --nodeps which means just that.
-	 * The downside is that there is a small window when our status is
-	 * invalid.
-	 * One workaround would be to introduce a new status,
-	 * or status locking. */
-	if (!deps) {
-		RC_SERVICE state = rc_service_state(service);
-		if (state & RC_SERVICE_STARTED || state & RC_SERVICE_INACTIVE)
-			svc_exec("stop", "start");
-		else
-			svc_exec("start", NULL);
-		return;
-	}
-
 	if (!(rc_service_state(service) & RC_SERVICE_STOPPED)) {
 		get_started_services();
 		svc_stop();

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -612,7 +612,7 @@ svc_start_check(void)
 	}
 
 	if (exclusive_fd == -1)
-		exclusive_fd = svc_lock(applet);
+		exclusive_fd = svc_lock(applet, !deps);
 	if (exclusive_fd == -1) {
 		if (errno == EACCES)
 			eerrorx("%s: superuser access required", applet);
@@ -864,7 +864,7 @@ svc_stop_check(RC_SERVICE *state)
 		exit(EXIT_FAILURE);
 
 	if (exclusive_fd == -1)
-		exclusive_fd = svc_lock(applet);
+		exclusive_fd = svc_lock(applet, !deps);
 	if (exclusive_fd == -1) {
 		if (errno == EACCES)
 			eerrorx("%s: superuser access required", applet);

--- a/src/shared/misc.h
+++ b/src/shared/misc.h
@@ -50,7 +50,7 @@ void env_filter(void);
 void env_config(void);
 int signal_setup(int sig, void (*handler)(int));
 int signal_setup_restart(int sig, void (*handler)(int));
-int svc_lock(const char *);
+int svc_lock(const char *, bool);
 int svc_unlock(const char *, int);
 pid_t exec_service(const char *, const char *);
 


### PR DESCRIPTION
```
restarting a service with --no-deps ran into a "hairy workaround", which
had a few problems discussed in [1]:
 - it ignores --dry-run, really restarting the requested service
 - if the service was stopped, the program is started but the service
status stays stopped. This makes long-lived services impossible to
(re)start again (pid already exists and running), and the service also
won't stop on shutdown.

The kludge had a long comment describing the following situation:
 - openvpn needs net and dns
 - net restarts dns
 - dns needs net

If the restart in net handled deps, openrc would deadlock waiting for
net in dns' restart, as net won't be started until that is done.

Restarting with --nodeps works around the deadlock, but can display
errors without the kludge (note that the services did start properly
anyway, the problem is that the default service path tries to lock dns
twice from openvn's dep's start and net's start's restart):
---
alpine:~# rc-service openvn start
openvn                   | * Caching service dependencies ...                                                                                                      [ ok ]
net                      |net starting
net                      |dns                       | * Call to flock failed: Resource temporarily unavailable
net                      |dns                       | * ERROR: dns stopped by something else
net                      |net started
dns                      |dns started
openvn                   |openvn started
alpine:~# rc-status | grep s[1-3]
 net                                                               [  started  ]
 dns                                                               [  started  ]
 openvn                                                            [  started  ]
---

Locking again in restart --nodep can fail in two patterns:
 - openvpn's need dependency start was first, and the restart in net
failed (case above): we can just silence locking failures and exit quietly
with restart --no-deps, which is not worse than trying to restart while
another process hold the lock.
 - the restart in net's start was first, and openvpn's need dependency
start failed: not much can be done here short of adding a new status
that a no-deps restart is in progress as in the comment, but this case
can actually just be solved by adjusting dependencies -- and it actually
has already been fixed: the current openvpn init script in alpine only
'use dns', so it will not try to start it, and that will start just
fine with openvpn -> net -> dns only each starting each other once
sequentially.

Another failure pattern is just starting dns directly: that will start
net, which will try to restart dns while we are starting it.
Silencing messages on restart also solves this.

Link: https://github.com/OpenRC/openrc/issues/224 [1]
```

------
- I've kept the actual silencing in a separate commit as that can be controversial, in my opinion it's still a bad dependency e.g. dns shouldn't depend on net in this case, but I guess we can try to keep working what used to "work"
- while checking this works I ran into a race with rc_parallel and a tty, the input loop in svc_exec() breaks loop on sigchld but the child might not be the one was just started, so the service can fail in this case; it's a bit annoying to fix and unrelated so I'll open a separate PR for that...

I've used the following services to test all different scenarii, many many times.
```
───────┬──────────────────────────────────────────────────────────────
       │ File: /etc/init.d/s1
───────┼──────────────────────────────────────────────────────────────
   1   │ #!/sbin/openrc-run
   2   │ 
   3   │ name="'openvpn'"
   4   │ description="Requires s2 (net) and needs s3 (dns)"
   5   │ 
   6   │ 
   7   │ depend() {
   8   │     need s2
   9   │     use  s3 # or both in need
  10   │ }
  11   │ 
  12   │ start() {
  13   │     echo s1 started
  14   │ }
  15   │ 
  16   │ stop() {
  17   │     echo s1 stopped
  18   │ }
───────┴──────────────────────────────────────────────────────────────
───────┬──────────────────────────────────────────────────────────────
       │ File: /etc/init.d/s2
───────┼──────────────────────────────────────────────────────────────
   1   │ #!/sbin/openrc-run
   2   │ 
   3   │ name="'net'"
   4   │ description="restarts s3 (dns)"
   5   │ 
   6   │ 
   7   │ depend() {
   8   │     :
   9   │ }
  10   │ 
  11   │ start() {
  12   │     echo s2 starting
  13   │     rc-service s3 restart --nodeps
  14   │     echo s2 started
  15   │ 
  16   │ }
  17   │ 
  18   │ stop() {
  19   │     echo s2 stopped
  20   │ }
───────┴──────────────────────────────────────────────────────────────
───────┬──────────────────────────────────────────────────────────────
       │ File: /etc/init.d/s3
───────┼──────────────────────────────────────────────────────────────
   1   │ #!/sbin/openrc-run
   2   │ 
   3   │ name="'dns'"
   4   │ description="need s2"
   5   │ 
   6   │ 
   7   │ depend() {
   8   │     need s2
   9   │ }
  10   │ start() {
  11   │     echo s3 started
  12   │ }
  13   │ stop() {
  14   │     echo s3 stopped
  15   │ }
───────┴──────────────────────────────────────────────────────────────
```

Fixes #224 