### PR TITLE
seedrng: fix copyright year

### DIFF
--- a/src/seedrng/seedrng.c
+++ b/src/seedrng/seedrng.c
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2023 The OpenRC Authors.
+ * Copyright (c) 2022-2023 The OpenRC Authors.
  * See the Authors file at the top-level directory of this distribution and
  * https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
  *


### PR DESCRIPTION
this was mistakenly changed to 2023 instead of 2022-2023 in 63a5ee3d