### PR TITLE
openrc-init: Make openrc-init respect -q (quiet)

### DIFF
--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 	bool reexec = false;
 	sigset_t signals;
 	int opt;
-    bool isquiet;
+	bool isquiet;
 	struct sigaction sa;
 #ifdef HAVE_SELINUX
 	int			enforce = 0;
@@ -265,18 +265,18 @@ int main(int argc, char **argv)
 	
 	default_runlevel = NULL;
 
-    while ((opt = getopt(argc, argv, "r:q")) != -1) {
-    	switch (opt) {
-    		case 'r':
-    			default_runlevel = optarg;
-    		case 'q':
-                isquiet = true;  
-    	}
-    }
+	while ((opt = getopt(argc, argv, "r:q")) != -1) {
+		switch (opt) {
+			case 'r':
+				default_runlevel = optarg;
+			case 'q':
+				isquiet = true;  
+		}
+	}
 
-    if (!isquiet) {
-	    printf("OpenRC init version %s starting\n", VERSION);
-    }
+	if (!isquiet) {
+		printf("OpenRC init version %s starting\n", VERSION);
+	}
 
 	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -230,6 +230,8 @@ int main(int argc, char **argv)
 	FILE *fifo;
 	bool reexec = false;
 	sigset_t signals;
+	int opt;
+    bool isquiet;
 	struct sigaction sa;
 #ifdef HAVE_SELINUX
 	int			enforce = 0;
@@ -260,13 +262,21 @@ int main(int argc, char **argv)
 		}
 	}
 #endif
+	
+	default_runlevel = NULL;
 
-	printf("OpenRC init version %s starting\n", VERSION);
+    while ((opt = getopt(argc, argv, "r:q")) != -1) {
+    	switch (opt) {
+    		case 'r':
+    			default_runlevel = optarg;
+    		case 'q':
+                isquiet = true;  
+    	}
+    }
 
-	if (argc > 1)
-		default_runlevel = argv[1];
-	else
-		default_runlevel = NULL;
+    if (!isquiet) {
+	    printf("OpenRC init version %s starting\n", VERSION);
+    }
 
 	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;


### PR DESCRIPTION
Fixed #487. I did change how you define the default runlevel (now it requires having -r before it), so if that's something which you don't want, then sorry.