### PR TITLE
openrc-init: Make openrc-init respect -q (quiet)

### DIFF
--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -272,8 +272,10 @@ int main(int argc, char **argv)
 
 	if (argc > 1)
 		default_runlevel = argv[optind];
+	else
+		default_runlevel = NULL;
 
-    if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
+	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;
 
 	/* block all signals we do not handle */

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -262,7 +262,7 @@ int main(int argc, char **argv)
 		}
 	}
 #endif
-	
+
 	default_runlevel = NULL;
 
 	while ((opt = getopt(argc, argv, "r:q")) != -1) {
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
 			case 'r':
 				default_runlevel = optarg;
 			case 'q':
-				isquiet = true;  
+				isquiet = true;
 		}
 	}
 

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 	bool reexec = false;
 	sigset_t signals;
 	int opt;
-    bool isquiet;
+	bool isquiet;
 	struct sigaction sa;
 #ifdef HAVE_SELINUX
 	int			enforce = 0;
@@ -265,18 +265,18 @@ int main(int argc, char **argv)
 	
 	default_runlevel = NULL;
 
-    while ((opt = getopt(argc, argv, "r:q")) != -1) {
-    	switch (opt) {
-    		case 'r':
-    			default_runlevel = optarg;
-    		case 'q':
-                isquiet = true;  
-    	}
-    }
+	while ((opt = getopt(argc, argv, "r:q")) != -1) {
+		switch (opt) {
+			case 'r':
+				default_runlevel = optarg;
+			case 'q':
+				isquiet = true;  
+		}
+	}
 
-    if (!isquiet) {
-	    printf("OpenRC init version %s starting\n", VERSION);
-    }
+	if (!isquiet) {
+		printf("OpenRC init version %s starting\n", VERSION);
+	}
 
 	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -230,6 +230,8 @@ int main(int argc, char **argv)
 	FILE *fifo;
 	bool reexec = false;
 	sigset_t signals;
+	int opt;
+    bool isquiet;
 	struct sigaction sa;
 #ifdef HAVE_SELINUX
 	int			enforce = 0;
@@ -260,13 +262,21 @@ int main(int argc, char **argv)
 		}
 	}
 #endif
+	
+	default_runlevel = NULL;
 
-	printf("OpenRC init version %s starting\n", VERSION);
+    while ((opt = getopt(argc, argv, "r:q")) != -1) {
+    	switch (opt) {
+    		case 'r':
+    			default_runlevel = optarg;
+    		case 'q':
+                isquiet = true;  
+    	}
+    }
 
-	if (argc > 1)
-		default_runlevel = argv[1];
-	else
-		default_runlevel = NULL;
+    if (!isquiet) {
+	    printf("OpenRC init version %s starting\n", VERSION);
+    }
 
 	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -273,9 +273,7 @@ int main(int argc, char **argv)
 	if (argc > 1)
 		default_runlevel = argv[optind];
 
-    printf("The current runlevel is %s\n", default_runlevel);
-
-	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
+    if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;
 
 	/* block all signals we do not handle */

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -230,7 +230,7 @@ int main(int argc, char **argv)
 	FILE *fifo;
 	bool reexec = false;
 	sigset_t signals;
-	bool isquiet;
+	bool isquiet = false;
 	struct sigaction sa;
 #ifdef HAVE_SELINUX
 	int			enforce = 0;
@@ -262,10 +262,8 @@ int main(int argc, char **argv)
 	}
 #endif
 
-	default_runlevel = NULL;
-
 	if (getopt(argc, argv, "q") == 'q')
-				isquiet = true;
+		isquiet = true;
 
 	if (!isquiet)
 		printf("OpenRC init version %s starting\n", VERSION);

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -230,7 +230,6 @@ int main(int argc, char **argv)
 	FILE *fifo;
 	bool reexec = false;
 	sigset_t signals;
-	int opt;
 	bool isquiet;
 	struct sigaction sa;
 #ifdef HAVE_SELINUX
@@ -265,18 +264,16 @@ int main(int argc, char **argv)
 
 	default_runlevel = NULL;
 
-	while ((opt = getopt(argc, argv, "r:q")) != -1) {
-		switch (opt) {
-			case 'r':
-				default_runlevel = optarg;
-			case 'q':
+	if (getopt(argc, argv, "q") == 'q')
 				isquiet = true;
-		}
-	}
 
-	if (!isquiet) {
+	if (!isquiet)
 		printf("OpenRC init version %s starting\n", VERSION);
-	}
+
+	if (argc > 1)
+		default_runlevel = argv[optind];
+
+    printf("The current runlevel is %s\n", default_runlevel);
 
 	if (default_runlevel && strcmp(default_runlevel, "reexec") == 0)
 		reexec = true;


### PR DESCRIPTION
Fixed #487. ~~Although I did change how you specify default runlevels (you have to put -r before it), so if you didn't want that, then sorry.~~