### PR TITLE
Silence "OpenRC is starting up" when run with --quiet

### DIFF
--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -459,17 +459,19 @@ do_sysinit(void)
 		run_program(INITEARLYSH);
 
 	uname(&uts);
-	printf("\n   %sOpenRC %s" VERSION "%s is starting up %s",
-	    ecolor(ECOLOR_GOOD), ecolor(ECOLOR_HILITE),
-	    ecolor(ECOLOR_NORMAL), ecolor(ECOLOR_BRACKET));
-#ifdef BRANDING
-	printf(BRANDING " (%s)", uts.machine);
-#else
-	printf("%s %s (%s)",
-	    uts.sysname,
-	    uts.release,
-	    uts.machine);
-#endif
+	if (!rc_yesno(getenv ("EINFO_QUIET")) {
+		printf("\n   %sOpenRC %s" VERSION "%s is starting up %s",
+		    ecolor(ECOLOR_GOOD), ecolor(ECOLOR_HILITE),
+	    	    ecolor(ECOLOR_NORMAL), ecolor(ECOLOR_BRACKET));
+	#ifdef BRANDING
+		printf(BRANDING " (%s)", uts.machine);
+	#else
+		printf("%s %s (%s)",
+	    	    uts.sysname,
+	    	    uts.release,
+	    	    uts.machine);
+	#endif
+	}
 
 	if ((sys = rc_sys()))
 		printf(" [%s]", sys);

--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -459,7 +459,7 @@ do_sysinit(void)
 		run_program(INITEARLYSH);
 
 	uname(&uts);
-	if (!rc_yesno(getenv ("EINFO_QUIET")) {
+	if (!rc_yesno(getenv ("EINFO_QUIET"))) {
 		printf("\n   %sOpenRC %s" VERSION "%s is starting up %s",
 		    ecolor(ECOLOR_GOOD), ecolor(ECOLOR_HILITE),
 	    	    ecolor(ECOLOR_NORMAL), ecolor(ECOLOR_BRACKET));


### PR DESCRIPTION
Silencing the "OpenRC is starting up" line with a kernel built with `CONFIG_FRAMEBUFFER_CONSOLE_DEFERRED_TAKEOVER` will retain the vendor boot logo set up by UEFI until something is written to the screen which results in a simplistic "splash" implementation (useful on embedded systems - no need for Plymouth).