### PR TITLE
Drop use of custom _unused

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -176,7 +176,10 @@ cc_warning_flags_test = [
   '-Wsequence-point',
   '-Wshadow',
   '-Wwrite-strings',
+  '-Werror=implicit-int',
   '-Werror=implicit-function-declaration',
+  '-Werror=int-conversion',
+  '-Werror=incompatible-function-pointer-types',
   ]
 cc_warning_flags = cc.get_supported_arguments(cc_warning_flags_test)
 cc_flags = [cc_debug_flags, cc_os_flags, cc_warning_flags]

--- a/src/libeinfo/einfo.h
+++ b/src/libeinfo/einfo.h
@@ -13,13 +13,8 @@
 #ifndef __EINFO_H__
 #define __EINFO_H__
 
-#if defined(__GNUC__)
-# define EINFO_PRINTF(a, b)  __attribute__((__format__(__printf__, a, b)))
-# define EINFO_XPRINTF(a, b) __attribute__((__noreturn__,__format__(__printf__, a, b)))
-#else
-# define EINFO_PRINTF(a, b)
-# define EINFO_XPRINTF(a, b)
-#endif
+#define EINFO_PRINTF(a, b)  __attribute__((__format__(__printf__, a, b)))
+#define EINFO_XPRINTF(a, b) __attribute__((__noreturn__, __format__(__printf__, a, b)))
 
 #include <sys/types.h>
 #include <stdbool.h>

--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -127,7 +127,7 @@ rc_getline(char **line, size_t *len, FILE *fp)
 }
 
 char *
-rc_proc_getent(const char *ent _unused)
+rc_proc_getent(const char *ent RC_UNUSED)
 {
 #ifdef __linux__
 	FILE *fp;

--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -249,7 +249,7 @@ detect_prefix(const char *systype)
 }
 
 static const char *
-detect_container(const char *systype _unused)
+detect_container(const char *systype RC_UNUSED)
 {
 #ifdef __FreeBSD__
 	if (systype) {
@@ -313,7 +313,7 @@ detect_container(const char *systype _unused)
 }
 
 static const char *
-detect_vm(const char *systype _unused)
+detect_vm(const char *systype RC_UNUSED)
 {
 #ifdef __NetBSD__
 	if (systype) {

--- a/src/openrc-shutdown/broadcast.c
+++ b/src/openrc-shutdown/broadcast.c
@@ -42,8 +42,7 @@ static sigjmp_buf jbuf;
 /*
  *	Alarm handler
  */
-/*ARGSUSED*/
-_noreturn static void handler(int arg _unused)
+RC_NORETURN static void handler(int arg RC_UNUSED)
 {
 	siglongjmp(jbuf, 1);
 }

--- a/src/openrc-shutdown/openrc-shutdown.c
+++ b/src/openrc-shutdown/openrc-shutdown.c
@@ -170,7 +170,7 @@ static void sleep_no_interrupt(int seconds)
 		duration = remaining;
 }
 
-_noreturn static void stop_shutdown(int sig)
+RC_NORETURN static void stop_shutdown(int sig)
 {
 	(void) sig;
 	unlink(nologin_file);

--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -690,7 +690,7 @@ do_start_services(const RC_STRINGLIST *start_services, bool parallel)
 }
 
 #ifdef RC_DEBUG
-_noreturn static void
+RC_NORETURN static void
 handle_bad_signal(int sig)
 {
 	char pid[10];

--- a/src/shared/_usage.c
+++ b/src/shared/_usage.c
@@ -36,7 +36,7 @@ void set_quiet_options(void)
 	}
 }
 
-_noreturn void show_version(void)
+RC_NORETURN void show_version(void)
 {
 	const char *systype = NULL;
 
@@ -51,7 +51,7 @@ _noreturn void show_version(void)
 	exit(EXIT_SUCCESS);
 }
 
-_noreturn void usage(int exit_status)
+RC_NORETURN void usage(int exit_status)
 {
 	const char * const has_arg[] = { "", "<arg>", "[arg]" };
 	int i;

--- a/src/shared/helpers.h
+++ b/src/shared/helpers.h
@@ -30,20 +30,9 @@
 
 #define UNCONST(a)		((void *)(unsigned long)(const void *)(a))
 
-#ifdef lint
-# define _unused
-#endif
-#if __GNUC__ > 2 || defined(__INTEL_COMPILER)
-# define _dead __attribute__((__noreturn__))
-# define _noreturn __attribute__ ((__noreturn__))
-# define _unused __attribute__((__unused__))
-# define _xasprintf(a, b)  __attribute__((__format__(__printf__, a, b)))
-#else
-# define _dead
-# define _noreturn
-# define _unused
-# define _xasprintf(a, b)
-#endif
+#define RC_UNUSED __attribute__((__unused__))
+#define RC_NORETURN __attribute__((__noreturn__))
+#define RC_PRINTF(a, b)  __attribute__((__format__(__printf__, a, b)))
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
@@ -65,7 +54,7 @@
 	} while (/* CONSTCOND */ 0)
 #endif
 
-_unused static void *xmalloc (size_t size)
+RC_UNUSED static void *xmalloc (size_t size)
 {
 	void *value = malloc(size);
 
@@ -76,7 +65,7 @@ _unused static void *xmalloc (size_t size)
 	/* NOTREACHED */
 }
 
-_unused static void *xrealloc(void *ptr, size_t size)
+RC_UNUSED static void *xrealloc(void *ptr, size_t size)
 {
 	void *value = realloc(ptr, size);
 
@@ -87,7 +76,7 @@ _unused static void *xrealloc(void *ptr, size_t size)
 	/* NOTREACHED */
 }
 
-_unused static char *xstrdup(const char *str)
+RC_UNUSED static char *xstrdup(const char *str)
 {
 	char *value;
 
@@ -109,7 +98,7 @@ _unused static char *xstrdup(const char *str)
  * basename_c never modifies the argument. As such, if there is a trailing
  * slash then an empty string is returned.
  */
-_unused static const char *basename_c(const char *path)
+RC_UNUSED static const char *basename_c(const char *path)
 {
 	const char *slash = strrchr(path, '/');
 
@@ -118,14 +107,14 @@ _unused static const char *basename_c(const char *path)
 	return (path);
 }
 
-_unused static bool exists(const char *pathname)
+RC_UNUSED static bool exists(const char *pathname)
 {
 	struct stat buf;
 
 	return (stat(pathname, &buf) == 0);
 }
 
-_unused static bool existss(const char *pathname)
+RC_UNUSED static bool existss(const char *pathname)
 {
 	struct stat buf;
 
@@ -140,7 +129,7 @@ _unused static bool existss(const char *pathname)
  * functions to handle memory allocation.
  * this function was originally written by Mike Frysinger.
  */
-_unused _xasprintf(2,3) static int xasprintf(char **strp, const char *fmt, ...)
+RC_UNUSED RC_PRINTF(2,3) static int xasprintf(char **strp, const char *fmt, ...)
 {
 	va_list ap;
 	int len;

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -179,9 +179,9 @@ extern char **environ;
 # define SYS_ioprio_set __NR_ioprio_set
 #endif
 #if !defined(__DragonFly__)
-static inline int ioprio_set(int which _unused,
-			     int who _unused,
-			     int ioprio _unused)
+static inline int ioprio_set(int which RC_UNUSED,
+			     int who RC_UNUSED,
+			     int ioprio RC_UNUSED)
 {
 #ifdef SYS_ioprio_set
 	return syscall(SYS_ioprio_set, which, who, ioprio);

--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -192,8 +192,8 @@ extern char **environ;
 # define SYS_ioprio_set __NR_ioprio_set
 #endif
 #if !defined(__DragonFly__)
-static inline int ioprio_set(int which _unused, int who _unused,
-			     int ioprio _unused)
+static inline int ioprio_set(int which RC_UNUSED, int who RC_UNUSED,
+			     int ioprio RC_UNUSED)
 {
 #ifdef SYS_ioprio_set
 	return syscall(SYS_ioprio_set, which, who, ioprio);
@@ -208,7 +208,7 @@ static void cleanup(void)
 	free(changeuser);
 }
 
-_noreturn static void re_exec_supervisor(void)
+RC_NORETURN static void re_exec_supervisor(void)
 {
 	syslog(LOG_WARNING, "Re-executing for %s", svcname);
 	execlp("supervise-daemon", "supervise-daemon", svcname, "--reexec",
@@ -354,7 +354,7 @@ static pid_t exec_command(const char *cmd)
 	return pid;
 }
 
-_noreturn static void child_process(char *exec, char **argv)
+RC_NORETURN static void child_process(char *exec, char **argv)
 {
 	RC_STRINGLIST *env_list;
 	RC_STRING *env;
@@ -587,7 +587,7 @@ _noreturn static void child_process(char *exec, char **argv)
 	eerrorx("%s: failed to exec `%s': %s", applet, exec,strerror(errno));
 }
 
-_noreturn static void supervisor(char *exec, char **argv)
+RC_NORETURN static void supervisor(char *exec, char **argv)
 {
 	FILE *fp;
 	char buf[2048];


### PR DESCRIPTION
Rename attribute macros to namespaced RC_*

This conflicts with linux-headers which uses __unused for some padding members
on ppc64le at least.

Closes: https://github.com/OpenRC/openrc/issues/622