### PR TITLE
librc: allow overriding rc_interactive on kernel command line

### DIFF
--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -287,6 +287,7 @@ static RC_STRINGLIST *rc_config_kcl(RC_STRINGLIST *config)
 	overrides = rc_stringlist_new();
 
 	/* A list of variables which may be overridden on the kernel command line */
+	rc_stringlist_add(overrides, "rc_interactive");
 	rc_stringlist_add(overrides, "rc_parallel");
 
 	TAILQ_FOREACH(override, overrides, entries) {


### PR DESCRIPTION
This was originally introduced in 14625346c07a2a66fe77ce578c9423918bec1d97 with an example list (just one for rc_parallel) of options. Let's add in rc_interactive as it's a pretty obvious thing one might want to override.

See https://forums.gentoo.org/viewtopic-p-8694588.html.