### PR TITLE
man: Remove Duplicate Description of -2/--stderr Flag

### DIFF
--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -183,10 +183,6 @@ Wait
 after starting and check that daemon is still running.
 Useful for daemons that check configuration after forking or stopping race
 conditions where the pidfile is written out after forking.
-.It Fl 2 , -stderr Ar logfile
-The same thing as
-.Fl 1 , -stdout
-but with the standard error output.
 .El
 .Pp
 These options are only used for stopping daemons:


### PR DESCRIPTION
This commit removes the secondary mention of the -2/--stderr flag in the start-stop-daemon man page. The flag's functionality was already sufficiently described in an earlier section of the text.