### PR TITLE
rc: fix automatic restart with runlevel-specific conf.d files

### DIFF
--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -527,7 +527,7 @@ runlevel_config(const char *service, const char *level)
 	char *conf, *dir;
 	bool retval;
 
-	dir = dirname(init);
+	dir = dirname(dirname(init));
 	xasprintf(&conf, "%s/conf.d/%s.%s", dir, service, level);
 	retval = exists(conf);
 	free(conf);


### PR DESCRIPTION
Commit fc4f15d6cd8e7884f7094e5d3749b01f2d5a448f broke the automatic restart of services having runlevel-specific conf.d files.

The double dirname() is not a mistake, but the way of getting from the service script in init.d to the upper directory containing the conf.d directory. dirname() modifies the argument in-place, so the second call operated on a modified value. To make it more obvious what is going on, have the second call operate on the returned value from the first call.

Fixes: fc4f15d ("openrc: fix double-assignment to dir")