### PR TITLE
start-stop-daemon, supervise-daemon: use close_range with musl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -197,6 +197,8 @@ endif
 
 if cc.has_function('close_range', prefix: '#define _GNU_SOURCE\n#include <unistd.h>')
   add_project_arguments('-DHAVE_CLOSE_RANGE', language: 'c')
+elif cc.has_header('linux/close_range.h')
+  add_project_arguments('-DHAVE_LINUX_CLOSE_RANGE_H', language: 'c')
 endif
 
 if cc.has_function('strlcpy', prefix: '#define _GNU_SOURCE\n#include <string.h>')

--- a/meson.build
+++ b/meson.build
@@ -195,9 +195,6 @@ if cc.compiles(malloc_attribute_test, name : 'malloc attribute with arguments')
   add_project_arguments('-DHAVE_MALLOC_EXTENDED_ATTRIBUTE', language: 'c')
 endif
 
-if cc.has_function('closefrom', prefix: '#define _GNU_SOURCE\n#include <unistd.h>')
-  add_project_arguments('-DHAVE_CLOSEFROM', language: 'c')
-endif
 if cc.has_function('close_range', prefix: '#define _GNU_SOURCE\n#include <unistd.h>')
   add_project_arguments('-DHAVE_CLOSE_RANGE', language: 'c')
 endif

--- a/meson.build
+++ b/meson.build
@@ -198,9 +198,8 @@ endif
 if cc.has_function('closefrom', prefix: '#define _GNU_SOURCE\n#include <unistd.h>')
   add_project_arguments('-DHAVE_CLOSEFROM', language: 'c')
 endif
-if cc.has_function('close_range', prefix: '#define _GNU_SOURCE\n#include <unistd.h>') and \
-    cc.has_header_symbol('unistd.h', 'CLOSE_RANGE_CLOEXEC', prefix: '#define _GNU_SOURCE')
-  add_project_arguments('-DHAVE_CLOSE_RANGE_CLOEXEC', language: 'c')
+if cc.has_function('close_range', prefix: '#define _GNU_SOURCE\n#include <unistd.h>')
+  add_project_arguments('-DHAVE_CLOSE_RANGE', language: 'c')
 endif
 
 if cc.has_function('strlcpy', prefix: '#define _GNU_SOURCE\n#include <string.h>')

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -24,6 +24,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#ifdef HAVE_LINUX_CLOSE_RANGE_H
+#  include <linux/close_range.h>
+#endif
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +34,7 @@
 #include <sys/file.h>
 #include <sys/time.h>
 #ifdef __linux__
+#  include <sys/syscall.h> /* for close_range */
 #  include <sys/sysinfo.h>
 #endif
 #include <sys/types.h>
@@ -511,7 +515,12 @@ static inline int close_range(int first RC_UNUSED,
 			      int last RC_UNUSED,
 			      unsigned int flags RC_UNUSED)
 {
+#ifdef SYS_close_range
+	return syscall(SYS_close_range, first, last, flags);
+#else
+	errno = ENOSYS;
 	return -1;
+#endif
 }
 #endif
 #ifndef CLOSE_RANGE_CLOEXEC

--- a/src/shared/misc.h
+++ b/src/shared/misc.h
@@ -73,4 +73,6 @@ void from_time_t(char *time_string, time_t tv);
 time_t to_time_t(char *timestring);
 pid_t get_pid(const char *applet, const char *pidfile);
 
+void cloexec_fds_from(int);
+
 #endif

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -1098,12 +1098,7 @@ int main(int argc, char **argv)
 				|| rc_yesno(getenv("EINFO_QUIET")))
 			dup2(stderr_fd, STDERR_FILENO);
 
-#ifdef HAVE_CLOSEFROM
-		closefrom(3);
-#else
-		for (i = getdtablesize() - 1; i >= 3; --i)
-			close(i);
-#endif
+		cloexec_fds_from(3);
 
 		if (scheduler != NULL) {
 			int scheduler_index;

--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -22,11 +22,6 @@
 #define ONE_SECOND    1000000000
 #define ONE_MS           1000000
 
-#ifdef HAVE_CLOSE_RANGE
-/* For close_range() */
-# define _GNU_SOURCE
-#endif
-
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
@@ -200,18 +195,6 @@ static inline int ioprio_set(int which RC_UNUSED, int who RC_UNUSED,
 #else
 	return 0;
 #endif
-}
-#endif
-
-#ifndef CLOSE_RANGE_CLOEXEC
-# define CLOSE_RANGE_CLOEXEC	(1U << 2)
-#endif
-#ifndef HAVE_CLOSE_RANGE
-static inline int close_range(int first RC_UNUSED,
-			      int last RC_UNUSED,
-			      unsigned int flags RC_UNUSED)
-{
-	return -1;
 }
 #endif
 
@@ -582,9 +565,8 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 	if (redirect_stderr || rc_yesno(getenv("EINFO_QUIET")))
 		dup2(stderr_fd, STDERR_FILENO);
 
-	if (close_range(3, UINT_MAX, CLOSE_RANGE_CLOEXEC) < 0)
-		for (i = getdtablesize() - 1; i >= 3; --i)
-			fcntl(i, F_SETFD, FD_CLOEXEC);
+	cloexec_fds_from(3);
+
 	cmdline = make_cmdline(argv);
 	syslog(LOG_INFO, "Child command line: %s", cmdline);
 	free(cmdline);


### PR DESCRIPTION
Make sure that we use close_range also with musl libc, using syscall directly.

This fixes a severe performance issue when running openrc under docker where the maxfd may be 1G.