### PR TITLE
Don't re-define strlcpy/strlcat with >=glibc-2.38

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -203,6 +203,10 @@ if cc.has_function('close_range', prefix: '#define _GNU_SOURCE\n#include <unistd
   add_project_arguments('-DHAVE_CLOSE_RANGE_CLOEXEC', language: 'c')
 endif
 
+if cc.has_function('strlcpy', prefix: '#define _GNU_SOURCE\n#include <string.h>')
+  add_project_arguments('-DHAVE_STRLCPY', language: 'c')
+endif
+
 incdir = include_directories('src/shared')
 einfo_incdir = include_directories('src/libeinfo')
 rc_incdir = include_directories('src/librc')

--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -146,9 +146,7 @@ static const char *const color_terms[] = {
 };
 #endif
 
-/* strlcat and strlcpy are nice, shame glibc does not define them */
-#ifdef __GLIBC__
-#  if !defined (__UCLIBC__) && !defined (__dietlibc__)
+#ifndef HAVE_STRLCPY
 static size_t
 strlcat(char *dst, const char *src, size_t size)
 {
@@ -176,7 +174,6 @@ strlcat(char *dst, const char *src, size_t size)
 
 	return dst_n + (s - src);
 }
-#  endif
 #endif
 
 static bool

--- a/src/shared/helpers.h
+++ b/src/shared/helpers.h
@@ -37,10 +37,8 @@
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
-#ifdef __GLIBC__
-#  if !defined (__UCLIBC__) && !defined (__dietlibc__)
+#ifndef HAVE_STRLCPY
 #    define strlcpy(dst, src, size) snprintf(dst, size, "%s", src)
-#  endif
 #endif
 
 #ifndef timespecsub


### PR DESCRIPTION
`>=glibc-2.38` implements strlcpy, strlcat, etc so check for those functions
with Meson and don't provide conflicting prototypes.

Fixes: https://github.com/OpenRC/openrc/issues/643