### PR TITLE
supervise-daemon: implement output_logger and error_logger.

### DIFF
--- a/man/supervise-daemon.8
+++ b/man/supervise-daemon.8
@@ -158,6 +158,23 @@ The logfile can also be a named pipe.
 The same thing as
 .Fl 1 , -stdout
 but with the standard error output.
+.It Fl -stdout-logger Ar cmd
+Run cmd as a child process redirecting the standard output to the
+standard input of cmd when started with
+.Fl background .
+Cmd must be an absolute pathname, but relative to the path optionally given with
+.Fl r , -chroot .
+This process must be prepared to accept input on stdin and be able to
+log it or send it to another location.
+.It Fl -stderr-logger Ar cmd
+Run cmd as a child process and 
+Redirect the standard error of the process to the standard input of cmd
+when started with
+.Fl background .
+Cmd must be an absolute pathname, but relative to the path optionally given with
+.Fl r , -chroot .
+This process must be prepared to accept input on stdin and be able to
+log it or send it to another location.
 .It Fl -capabilities Ar cap-list
 Start the daemon with the listed inheritable, ambient and bounding capabilities.
 The format is the same as in cap_iab(3).

--- a/sh/supervise-daemon.sh
+++ b/sh/supervise-daemon.sh
@@ -30,6 +30,8 @@ supervise_start()
 		${chroot:+--chroot} $chroot \
 		${output_log+--stdout} ${output_log} \
 		${error_log+--stderr} $error_log \
+		${output_logger:+--stdout-logger \"$output_logger\"} \
+		${error_logger:+--stderr-logger \"$error_logger\"} \
 		${pidfile:+--pidfile} $pidfile \
 		${respawn_delay:+--respawn-delay} $respawn_delay \
 		${respawn_max:+--respawn-max} $respawn_max \

--- a/src/supervise-daemon/meson.build
+++ b/src/supervise-daemon/meson.build
@@ -1,5 +1,5 @@
 executable('supervise-daemon',
-  ['supervise-daemon.c', misc_c, plugin_c, schedules_c, usage_c, version_h],
+  ['supervise-daemon.c', '../start-stop-daemon/pipes.c', misc_c, plugin_c, schedules_c, usage_c, version_h],
   c_args : [cc_branding_flags, cc_pam_flags, cc_cap_flags, cc_selinux_flags],
   link_with: [libeinfo, librc],
   dependencies: [dl_dep, pam_dep, cap_dep, util_dep, selinux_dep],


### PR DESCRIPTION
Implements #644. Allows redirecting process stdin and stdout to another process, just like is already possible with start-stop-daemon. Also addresses #341 and #118.

Almost all of the code is copied directly from s-s-d (#127). I tried to follow your coding style as best I could, I read several previously accepted PRs, and I tried to keep the diff to a minimum.

This works correctly on my machine (Alpine, x86_64) and is currently hosting several of my public services. The stdout and stderr output is successfully redirected to syslog on another machine, which is then emailed to me sometimes.

I didn't copy over the short command arg variants (-3 and -4) because -3 conflicts with supervise-daemon's "--reexec" which doesn't exist in s-s-d. I can edit if you prefer something else. 

As an example, here's a snippet from my /etc/init.d file(s):

```sh
#!/sbin/openrc-run

supervisor=supervise-daemon
output_logger="logger -et '${RC_SVCNAME}'"
error_logger="logger -et '${RC_SVCNAME}' -p3"

depend() {
	use logger
}
```

This forwards stdin and stdout to syslog. `-p3` sets the priority level to error. 