### PR TITLE
Force symlinking of openrc-init to init

### DIFF
--- a/tools/meson_final.sh
+++ b/tools/meson_final.sh
@@ -13,5 +13,5 @@ if [ "${os}" != Linux ]; then
 fi
 install -m 644 "${MESON_BUILD_ROOT}/src/shared/version" "${DESTDIR}/${rc_libexecdir}"
 if [ "${os}" = Linux ] && [ "${sysvinit}" = yes ]; then
-	ln -s openrc-init "${DESTDIR}/${sbindir}"/init
+	ln -sf openrc-init "${DESTDIR}/${sbindir}"/init
 fi


### PR DESCRIPTION
When building on embedded SDKs such as Buildroot or Yocto, if OpenRC has a previous installation, the package will fail the installation step as the openrc-init is already a symlink to "${DESTDIR}/${sbindir}"/init. Force symlinking to prevent errors when reinstalling the package.