### PR TITLE
symlink rather then duplicate multicall binaries

### DIFF
--- a/src/einfo/meson.build
+++ b/src/einfo/meson.build
@@ -1,6 +1,5 @@
 einfo_execs = [
   'einfon',
-  'einfo',
   'ewarnn',
   'ewarn',
   'eerrorn',
@@ -22,11 +21,19 @@ einfo_execs = [
   'veoutdent',
   ]
 
-foreach exec: einfo_execs
-  executable(exec,
+executable('einfo',
     ['einfo.c', version_h],
     include_directories: [incdir, einfo_incdir, rc_incdir],
     link_with: [libeinfo, librc],
+    install: true,
+    install_dir: rc_bindir)
+
+foreach exec: einfo_execs
+  custom_target(exec,
+    output: exec,
+    command: ['ln', '-sf', 'einfo', '@OUTPUT@'],
+    build_always_stale: true,
+    build_by_default: true,
     install: true,
     install_dir: rc_bindir)
 endforeach

--- a/src/mark_service/meson.build
+++ b/src/mark_service/meson.build
@@ -1,5 +1,4 @@
 mark_service_execs =	[
-  'mark_service_starting',
   'mark_service_started',
   'mark_service_stopping',
   'mark_service_stopped',
@@ -10,11 +9,19 @@ mark_service_execs =	[
   'mark_service_crashed',
   ]
 
+executable('mark_service_starting',
+  ['mark_service.c', misc_c, version_h],
+  include_directories: [incdir, einfo_incdir, rc_incdir],
+  link_with: [libeinfo,librc],
+  install: true,
+  install_dir: rc_sbindir)
+
 foreach exec : mark_service_execs
-  executable(exec,
-    ['mark_service.c', misc_c, version_h],
-    include_directories: [incdir, einfo_incdir, rc_incdir],
-    link_with: [libeinfo,librc],
+  custom_target(exec,
+    output: exec,
+    command: ['ln', '-sf', 'mark_service_starting', '@OUTPUT@'],
+    build_always_stale: true,
+    build_by_default: true,
     install: true,
     install_dir: rc_sbindir)
 endforeach

--- a/src/service/meson.build
+++ b/src/service/meson.build
@@ -1,5 +1,4 @@
 service_execs = [
-  'service_starting',
   'service_started',
   'service_stopping',
   'service_stopped',
@@ -10,11 +9,19 @@ service_execs = [
   'service_crashed',
   ]
 
-foreach exec : service_execs
-  executable(exec,
+executable('service_starting',
     ['service.c', misc_c, version_h],
     include_directories: [incdir, einfo_incdir, rc_incdir],
     link_with: [libeinfo, librc],
+    install: true,
+    install_dir: rc_bindir)
+
+foreach exec : service_execs
+  custom_target(exec,
+    output: exec,
+    command: ['ln', '-sf', 'service_starting', '@OUTPUT@'],
+    build_always_stale: true,
+    build_by_default: true,
     install: true,
     install_dir: rc_bindir)
 endforeach

--- a/src/value/meson.build
+++ b/src/value/meson.build
@@ -1,15 +1,22 @@
 value_execs = [
-  'service_get_value',
   'service_set_value',
   'get_options',
   'save_options',
   ]
 
+executable('service_get_value',
+  ['value.c', misc_c, version_h],
+  include_directories: [incdir, einfo_incdir, rc_incdir],
+  link_with: [libeinfo, librc],
+  install: true,
+  install_dir: rc_bindir)
+
 foreach exec : value_execs
-  executable(exec,
-    ['value.c', misc_c, version_h],
-    include_directories: [incdir, einfo_incdir, rc_incdir],
-    link_with: [libeinfo, librc],
+  custom_target(exec,
+    output: exec,
+    command: ['ln', '-sf', 'service_get_value', '@OUTPUT@'],
+    build_always_stale: true,
+    build_by_default: true,
     install: true,
     install_dir: rc_bindir)
 endforeach


### PR DESCRIPTION
This was raised here, https://github.com/jsbronder/meta-openrc/pull/29.  As I said there, I think these changes are better done upstream if found acceptable instead of carrying patches or manually creating symlinks post-install.

> There is a bunch of binaries in OpenRC that are essentially multicall binaries, but redundantly compiled multiple times:
>
> https://github.com/OpenRC/openrc/blob/0.45.2/src/einfo/meson.build
> https://github.com/OpenRC/openrc/blob/0.45.2/src/service/meson.build
> https://github.com/OpenRC/openrc/blob/0.45.2/src/mark_service/meson.build
> https://github.com/OpenRC/openrc/blob/0.45.2/src/value/meson.build
>
> By symlinking them to one 'main' multicall binary per group, we can reduce rootfs size. As the minimum ARM binary size is pretty big thanks to default 64 kiB alignment in newer binutils, this can be pretty sizable. This saved about 8MB on my test build.