### PR TITLE
init.d/cgroups.in: fix inconsistency between mount_cgroups and mount_…

### DIFF
--- a/init.d/cgroups.in
+++ b/init.d/cgroups.in
@@ -87,7 +87,7 @@ cgroup2_controllers()
 	[ ! -e "${cgroup_path}/cgroup.subtree_control" ]&& return 0
 	read -r active < "${cgroup_path}/cgroup.controllers"
 	for x in ${active}; do
-	case "$rc_cgroup_mode" in
+	case "${rc_cgroup_mode:-unified}" in
 		unified)
 			echo "+${x}"  > "${cgroup_path}/cgroup.subtree_control"
 			;;


### PR DESCRIPTION
…cgroups

965de92b37cbe8d8670f6cc956e1d10677551e19 changed the default cgroup mode which exposes an issue in init.d/cgroups.in.

While mount_cgroups defaults to 'unified' if rc_cgroup_mode is unset, cgroup2_controllers has no default and therefore has a mismatch with the logic in mount_cgroups. The two should be consistent so the flow makes sense, as mount_cgroups expects a certain path to be taken in cgroup2_controllers.

Make cgroup2_controllers default to 'unified' if rc_cgroup_mode is unset, just like mount_cgroups.

Bug: https://bugs.gentoo.org/916964
Thanks-to: acab@digitalfuture.it