### PR TITLE
Masked LXC from the loopback boot script

### DIFF
--- a/init.d/loopback.in
+++ b/init.d/loopback.in
@@ -14,7 +14,7 @@ description="Configures the loopback interface."
 depend()
 {
 	after clock
-	keyword -jail -prefix -systemd-nspawn -vserver
+	keyword -jail -lxc -prefix -systemd-nspawn -vserver
 }
 
 start()


### PR DESCRIPTION
This is not required in a LXC container, and results in errors (which can be ignored) in unprivileged containers.