### PR TITLE
meson.build: fix uclibc build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -149,7 +149,7 @@ else
 endif
 
 if os == 'Linux' or os == 'GNU-kFreeBSD'
-  cc_os_flags = ['-D_DEFAULT_SOURCE']
+  cc_os_flags = ['-D_DEFAULT_SOURCE', '-D_GNU_SOURCE']
 elif os == 'FreeBSD'
   cc_os_flags = ['-D_BSD_SOURCE']
 elif os == 'GNU'


### PR DESCRIPTION
Fix the following uclibc build failures raised with meson because `kill` and `fileno` are not standard functions:

```
../src/rc-abort/rc-abort.c: In function 'main':
../src/rc-abort/rc-abort.c:27:21: error: implicit declaration of function 'kill'; did you mean 'killpg'? [-Werror=implicit-function-declaration]
   27 |                 if (kill(pid, SIGUSR1) != 0)
      |                     ^~~~
      |                     killpg

../src/libeinfo/libeinfo.c: In function 'colour_terminal': ../src/libeinfo/libeinfo.c:319:26: error: implicit declaration of function 'fileno' [-Werror=implicit-function-declaration]
  319 |         if (f && !isatty(fileno(f)))
      |                          ^~~~~~

../src/librc/librc-misc.c: In function 'rc_getfile': ../src/librc/librc-misc.c:79:14: error: implicit declaration of function 'fileno'; did you mean 'd_fileno'? [-Werror=implicit-function-declaration]
   79 |         fd = fileno(fp);
      |              ^~~~~~
      |              d_fileno

../src/librc/librc-daemon.c: In function 'rc_service_daemons_crashed': ../src/librc/librc-daemon.c:633:37: error: implicit declaration of function 'kill'; did you mean 'killpg'? [-Werror=implicit-function-declaration]
  633 |                                 if (kill(pid, 0) == -1 && errno == ESRCH)
      |                                     ^~~~
      |                                     killpg
```

Fixes:
 - http://autobuild.buildroot.org/results/494ef392a971ddb3c5c7b01e0149c6439018dbe7