### PR TITLE
init.d/swclock: use current time instead of default reference file

### DIFF
--- a/init.d/swclock.in
+++ b/init.d/swclock.in
@@ -24,7 +24,9 @@ start()
 {
 	ebegin "Setting the local clock based on last shutdown time"
 	if ! swclock "${swclock_file}" 2> /dev/null; then
-	swclock --warn @SBINDIR@/openrc-run
+		local curr_mtime="$(mktemp -q)"
+		swclock --warn "${curr_mtime}"
+		rm -f "${curr_mtime}"
 	fi
 	eend $?
 }


### PR DESCRIPTION
A default reference file mtime may send the clock backwards of current deptree mtime.
Fixes https://github.com/OpenRC/openrc/issues/675