### PR TITLE
enable confd cgroups mount options

### DIFF
--- a/conf.d/cgroups
+++ b/conf.d/cgroups
@@ -1,0 +1,2 @@
+# cgroup mount options
+#cgroup_opts=nodev,noexec,nosuid

--- a/init.d/cgroups.in
+++ b/init.d/cgroups.in
@@ -11,7 +11,8 @@
 
 description="Mount the control groups."
 
-cgroup_opts=nodev,noexec,nosuid
+# default mount options can be overriden in conf.d
+: "${cgroup_opts:="nodev,noexec,nosuid"}"
 
 depend()
 {


### PR DESCRIPTION
Added /etc/conf.d/cgroups to enable custom cgroup mount options.

For example the cgroup2 options `memory_localevents` and `favordynmods`.

Other mount options are described in:
- https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
- https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/cgroups.html