### PR TITLE
Drop PREFIX macro and fix for Gentoo prefix

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -563,7 +563,7 @@ A special variable to describe the system more.
 Possible values are OPENVZ, XENU, XEN0, UML and VSERVER.
 .It Va RC_PREFIX
 In a Gentoo Prefix installation, this variable contains the prefix
-offset. Otherwise it is undefined.
+offset. Otherwise it is empty string.
 .It Va RC_UNAME
 The result of `uname -s`.
 .It Va RC_CMD

--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -234,9 +234,6 @@ get_systype(void)
 static const char *
 detect_prefix(const char *systype)
 {
-#ifdef PREFIX
-	return RC_SYS_PREFIX;
-#else
 	if (systype) {
 		if (strcmp(systype, RC_SYS_NONE) == 0)
 			return NULL;
@@ -245,7 +242,6 @@ detect_prefix(const char *systype)
 	}
 
 	return NULL;
-#endif
 }
 
 static const char *

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -26,11 +26,10 @@ extern "C" {
 #define RC_SYSCONFDIR		"@SYSCONFDIR@"
 #define RC_LIBDIR               "@PREFIX@/@LIB@/rc"
 #define RC_LIBEXECDIR           "@LIBEXECDIR@"
-#if defined(PREFIX)
 #define RC_SVCDIR               RC_LIBEXECDIR "/init.d"
-#elif defined(__linux__) || (defined(__FreeBSD_kernel__) && \
+#if defined(__linux__) || (defined(__FreeBSD_kernel__) && \
 		defined(__GLIBC__)) || defined(__GNU__)
-#define RC_SVCDIR               "/run/openrc"
+#define RC_SVCDIR               RC_PREFIX "/run/openrc"
 #else
 #define RC_SVCDIR               RC_LIBEXECDIR "/init.d"
 #endif

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -197,9 +197,7 @@ env_config(void)
 	if (sys)
 		setenv("RC_SYS", sys, 1);
 
-#ifdef PREFIX
 	setenv("RC_PREFIX", RC_PREFIX, 1);
-#endif
 
 	/* Some scripts may need to take a different code path if
 	   Linux/FreeBSD, etc


### PR DESCRIPTION
This PR drops PREFIX macro, as another way of fixing for Gentoo prefix (the other way is enabling this macro in meson build system, see https://github.com/OpenRC/openrc/pull/672)

However, one commit breaks the a9272f50f75849f5d7a787cab4c54f5a2d158f58, by re-introducing prefix to `/run` directory, because Gentoo prefix may not have access to the unprefixied `/run`. That affects archlinux install, and perhaps merged `/usr` profile

Please review and judge which is the better way. Keep PREFIX macro, https://github.com/OpenRC/openrc/pull/672, or drop it, implemented in this PR?