### PR TITLE
start-stop-daemon: fix setting scheduler with musl

### DIFF
--- a/src/start-stop-daemon/meson.build
+++ b/src/start-stop-daemon/meson.build
@@ -3,7 +3,7 @@ executable('start-stop-daemon',
 	selinux_c, usage_c, version_h],
   c_args : [cc_audit_flags, cc_branding_flags, cc_pam_flags, cc_cap_flags, cc_selinux_flags],
   link_with: [libeinfo, librc],
-  dependencies: [audit_dep, dl_dep, pam_dep, cap_dep, pam_misc_dep, util_dep, selinux_dep, crypt_dep],
+  dependencies: [audit_dep, dl_dep, pam_dep, cap_dep, pam_misc_dep, util_dep, selinux_dep, crypt_dep, dependency('threads')],
   include_directories: [incdir, einfo_incdir, rc_incdir],
   install: true,
   install_dir: sbindir)

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -31,6 +31,7 @@
 #include <getopt.h>
 #include <limits.h>
 #include <grp.h>
+#include <pthread.h>
 #include <pwd.h>
 #include <sched.h>
 #include <signal.h>
@@ -1126,7 +1127,7 @@ int main(int argc, char **argv)
 			if (sched_prio == -1)
 				sched.sched_priority = sched_get_priority_min(scheduler_index);
 
-			if (sched_setscheduler(mypid, scheduler_index, &sched))
+			if (pthread_setschedparam(pthread_self(), scheduler_index, &sched))
 				eerrorx("Failed to set scheduler: %s", strerror(errno));
 		} else if (sched_prio != -1) {
 			const struct sched_param sched =  {.sched_priority = sched_prio};


### PR DESCRIPTION
musl sched_setscheduler() is only a stub in musl and the glibc implementation does "the wrong thing". Use pthread_setschedparam instead.

ref: https://www.openwall.com/lists/musl/2016/03/01/5
fixes: https://github.com/OpenRC/openrc/issues/689