### PR TITLE
Drop curses

### DIFF
--- a/man/einfo.3
+++ b/man/einfo.3
@@ -158,13 +158,6 @@ is true.
 prefixes the string
 .Fa prefix
 to the above functions.
-.Sh IMPLEMENTATION NOTES
-einfo can optionally be linked against the
-.Lb libtermcap
-so that we can correctly query the connected console for our color and
-cursor escape codes.
-If not, then we have a hard coded list of terminals we know about that support
-the commonly used codes for color and cursor position.
 .Sh ENVIRONMENT
 .Va EINFO_QUIET
 when set to true makes the

--- a/meson.build
+++ b/meson.build
@@ -133,15 +133,6 @@ else
   cc_selinux_flags = []
 endif
 
-termcap = get_option('termcap')
-if termcap != ''
-  termcap_dep = dependency(termcap)
-  termcap_flags = '-DHAVE_TERMCAP'
-  else
-  termcap_dep = []
-  termcap_flags = []
-endif
-
 if get_option('buildtype').startswith('debug')
   cc_debug_flags = ['-DRC_DEBUG']
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,9 +31,5 @@ option('split-usr', type : 'combo',
   description : '''/bin, /sbin aren't symlinks into /usr''')
 option('sysvinit', type : 'boolean', value : false,
   description : 'enable SysVinit compatibility (linux only)')
-option('termcap', type : 'combo',
-  choices :
-    [ '', 'ncurses', 'termcap' ],
-  description : 'the termcap library to use')
 option('zsh-completions', type : 'boolean',
   description : 'install zsh completions')

--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -50,8 +50,7 @@
 #define HILITE                  6
 #define BRACKET                 4
 
-/* We fallback to these escape codes if termcap isn't available
- * like say /usr isn't mounted */
+/* ANSI escape codes which mimic termcap */
 #define AF "\033[3%dm"
 #define CE "\033[K"
 #define CH "\033[%dC"
@@ -94,7 +93,7 @@ static char *goto_column = NULL;
 static const char *term = NULL;
 static bool term_is_cons25 = false;
 
-/* No curses support, so we hardcode a list of colour capable terms
+/* Hardcoded list of colour capable terms
  * Only terminals without "color" in the name need to be explicitly listed */
 static const char *const color_terms[] = {
 	"Eterm",

--- a/src/libeinfo/meson.build
+++ b/src/libeinfo/meson.build
@@ -1,9 +1,7 @@
 libeinfo_version = '1'
 
 libeinfo = library('einfo', ['libeinfo.c'],
-  c_args : termcap_flags,
   include_directories : incdir,
-  dependencies : termcap_dep,
   link_depends : 'einfo.map',
   version : libeinfo_version,
   install : true,


### PR DESCRIPTION
Remove the curses code and make the HAVE_TERMCAP-gated "fallbacks" always present. This makes an ANSI terminal required for colors.

X-Gentoo-Bug: https://bugs.gentoo.org/904277
Closes: https://github.com/OpenRC/openrc/issues/619