### PR TITLE
start-stop-daemon:  support cpu scheduler env variable

### DIFF
--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -203,6 +203,14 @@ option takes precedence.
 can also set the scheduling priority of the daemon, but the command line
 option takes precedence.
 .Pp
+.Va SSD_CPUSCHEDULER
+can also set the CPU scheduler of the daemon, but the command line
+option takes precedence.
+.Pp
+.Va SSD_CPUSCHEDULER_PRIO
+can also set the CPU scheduling priority of the daemon, but the command line
+option takes precedence.
+.Pp
 .Va SSD_OOM_SCORE_ADJ
 can also set the OOM score adjustment of the daemon, but the command line
 option takes precedence.

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -379,6 +379,19 @@ int main(int argc, char **argv)
 			eerror("%s: invalid oom_score_adj `%s' (SSD_OOM_SCORE_ADJ)",
 			    applet, tmp);
 
+	// Handle SSD_CPUSCHEDULER for scheduler type
+	if ((tmp = getenv("SSD_CPUSCHEDULER"))) {
+		scheduler = strdup(tmp); 
+	}
+	
+	// Handle SSD_CPUSCHEDULER_PRIO for scheduler priority
+	if ((tmp = getenv("SSD_CPUSCHEDULER_PRIO"))) {
+		if (sscanf(tmp, "%d", &sched_prio) != 1) {
+			eerror("%s: invalid scheduler priority `%s' (SSD_CPUSCHEDULER_PRIO)",
+						applet, tmp);
+		}
+	}
+
 	/* Get our user name and initial dir */
 	p = getenv("USER");
 	home = getenv("HOME");


### PR DESCRIPTION
Introduced `SSD_CPUSCHEDULER` and `SSD_CPUSCHEDULER_PRIO` environment variables to complement the `--scheduler` command line argument.