### PR TITLE
meson: drop broken split-usr handling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,16 +83,9 @@ else
   pkg_prefix = option_pkg_prefix
 endif
 
-if get_option('split-usr') == 'auto'
-  split_usr = run_command('test', '-L', '/bin', check: false).returncode() != 0
-else
-  split_usr = get_option('split-usr') == 'true'
-endif
-
 rootprefix = get_option('rootprefix')
-rootprefix_default = fs.is_symlink('/bin') ? '/usr' : '/'
 if rootprefix == ''
-rootprefix = rootprefix_default
+rootprefix = '/'
 endif
 
 bindir = rootprefix / get_option('bindir')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,9 +26,6 @@ option('selinux', type : 'feature', value : 'auto',
   description : 'enable SELinux support')
 option('shell', type : 'string', value : '/bin/sh',
   description : 'Default posix compatible shell')
-option('split-usr', type : 'combo',
-  choices : ['auto', 'true', 'false'],
-  description : '''/bin, /sbin aren't symlinks into /usr''')
 option('sysvinit', type : 'boolean', value : false,
   description : 'enable SysVinit compatibility (linux only)')
 option('termcap', type : 'combo',


### PR DESCRIPTION
meson: drop broken split-usr handling

Two issues here:

* The 'split-usr' meson option wasn't doing anything, it tried to check
  if /bin was a symlink, but nothing acted on this information.

* The actual rootprefix default was decided based on whether /bin was a symlink
  which is flaky if e.g. building on a merged-usr system for use on a non-merged-usr
  system.

People can set -Drootprefix=/usr if they wish.

There's no real advantage to installing to /usr over / as the compat. symlinks
are really here to stay. If someone really does care about this, they can bring
it back and do it properly, but it doesn't seem worth it to me at all.

Bug: https://bugs.gentoo.org/927776
Fixes: cc0037e9caaee05af0fdedafc5798c2a7aa9bdb8
Fixes: f2362cc277023550b2482215b4a1cd7142639427