### PR TITLE
Add xterm-kitty to color capable term list

### DIFF
--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -132,6 +132,7 @@ static const char *const color_terms[] = {
 	"wsvt25",
 	"xterm",
 	"xterm-debian",
+	"xterm-kitty",
 	NULL
 };
 


### PR DESCRIPTION
xterm-kitty is a wayland color capable terminal, so add it.