### PR TITLE
Add foot to color capable term list

### DIFF
--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -112,6 +112,7 @@ static const char *const color_terms[] = {
 	"console",
 	"cygwin",
 	"dtterm",
+	"foot",
 	"gnome",
 	"konsole",
 	"kterm",


### PR DESCRIPTION
foot is a wayland color capable terminal emulator with the default TERM being set to "foot"