### PR TITLE
shared: fix incompatible function warnings in plugin loader

### DIFF
--- a/src/shared/plugin.h
+++ b/src/shared/plugin.h
@@ -32,15 +32,4 @@ void rc_plugin_load(void);
 void rc_plugin_unload(void);
 void rc_plugin_run(RC_HOOK, const char *value);
 
-/* dlfunc defines needed to avoid ISO errors. FreeBSD has this right :) */
-#if !defined(__FreeBSD__) && !defined(__DragonFly__)
-struct __dlfunc_arg {
-	int	__dlfunc_dummy;
-};
-
-typedef	void (*dlfunc_t)(struct __dlfunc_arg);
-
-dlfunc_t dlfunc (void * __restrict handle, const char * __restrict symbol);
-#endif
-
 #endif


### PR DESCRIPTION
Declare a more specific function pointer type to be punned through a union. Fixes this warning:

```
[73/206] Compiling C object src/openrc/openrc.p/.._shared_plugin.c.o
../src/shared/plugin.c: In function ‘rc_plugin_load’:
../src/shared/plugin.c:94:24: warning: cast between incompatible function types from ‘dlfunc_t’ {aka ‘void (*)(struct __dlfunc_arg)’} to ‘int (*)(RC_HOOK,  const char *)’ [-Wcast-function-type]
   94 |                 fptr = (int (*)(RC_HOOK, const char *))
      |                        ^
```