### PR TITLE
sh/init.sh.Linux.in: remove uucp group from /run/lock

### DIFF
--- a/sh/init.sh.Linux.in
+++ b/sh/init.sh.Linux.in
@@ -83,7 +83,7 @@ elif ! mountinfo -q /run; then
 fi
 
 checkpath -d "$RC_SVCDIR"
-checkpath -d -m 0775 -o root:uucp /run/lock
+checkpath -d /run/lock
 
 # Try to mount xenfs as early as possible, otherwise rc_sys() will always
 # return RC_SYS_XENU and will think that we are in a domU while it's not.


### PR DESCRIPTION
I am not aware of a reason why the uucp group should have r/w access to /run/lock. Also the current configuration allows the uucp group to delete and replace entries owned by other users/groups from /run/lock which could be dangerous.

Ref https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/69933