### PR TITLE
make libcap a hard requirement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ endif
 
 if os != 'Linux'
   cap_dep = []
-  kvm_dep = cc.find_library('kvm', required: true)
+  kvm_dep = cc.find_library('kvm')
 else
   cap_dep = dependency('libcap', version: '>=2.33')
   kvm_dep = []

--- a/meson.build
+++ b/meson.build
@@ -45,8 +45,10 @@ else
 endif
 
 if os != 'Linux'
+  cap_dep = []
   kvm_dep = cc.find_library('kvm', required: true)
 else
+  cap_dep = dependency('libcap', version: '>=2.33')
   kvm_dep = []
 endif
 
@@ -62,13 +64,6 @@ endif
 
 if not pam_dep.found() and get_option('pam')
   error('Pam was requested but could not be located')
-endif
-
-cap_dep = dependency('libcap', version: '>=2.33', required : get_option('capabilities'))
-if cap_dep.found()
-  cc_cap_flags = '-DHAVE_CAP'
-else
-  cc_cap_flags = []
 endif
 
 option_pkg_prefix = get_option('pkg_prefix')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,8 +14,6 @@ option('os', type : 'combo',
   description : 'Operating System (autodetected if not specified)')
 option('pam', type : 'boolean',
   description : 'enable PAM support')
-option('capabilities', type : 'feature', value: 'auto',
-  description : 'enable capabilities support')
 option('pkg_prefix', type : 'string',
   description : 'default location where packages are installed')
 option('pkgconfig', type : 'boolean',

--- a/src/start-stop-daemon/meson.build
+++ b/src/start-stop-daemon/meson.build
@@ -1,7 +1,7 @@
 executable('start-stop-daemon',
   ['start-stop-daemon.c', pipes_c, misc_c, schedules_c,
 	selinux_c, usage_c, version_h],
-  c_args : [cc_audit_flags, cc_branding_flags, cc_pam_flags, cc_cap_flags, cc_selinux_flags],
+  c_args : [cc_audit_flags, cc_branding_flags, cc_pam_flags, cc_selinux_flags],
   link_with: [libeinfo, librc],
   dependencies: [audit_dep, dl_dep, pam_dep, cap_dep, pam_misc_dep, util_dep, selinux_dep, crypt_dep, dependency('threads')],
   include_directories: [incdir, einfo_incdir, rc_incdir],

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -62,7 +62,7 @@
 static struct pam_conv conv = { NULL, NULL};
 #endif
 
-#ifdef HAVE_CAP
+#ifdef __linux__
 # include <sys/capability.h>
 #endif
 
@@ -343,7 +343,7 @@ int main(int argc, char **argv)
 	unsigned int start_wait = 0;
 	const char *scheduler = NULL;
 	int sched_prio = -1;
-#ifdef HAVE_CAP
+#ifdef __linux__
 	cap_iab_t cap_iab = NULL;
 	unsigned secbits = 0;
 #endif
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
 		    (int *) 0)) != -1)
 		switch (opt) {
 		case LONGOPT_CAPABILITIES:
-#ifdef HAVE_CAP
+#ifdef __linux__
 			cap_iab = cap_iab_from_text(optarg);
 			if (cap_iab == NULL)
 				eerrorx("Could not parse iab: %s", strerror(errno));
@@ -412,7 +412,7 @@ int main(int argc, char **argv)
 			break;
 
 		case LONGOPT_SECBITS:
-#ifdef HAVE_CAP
+#ifdef __linux__
 			if (*optarg == '\0')
 				eerrorx("Secbits are empty");
 
@@ -955,7 +955,7 @@ int main(int argc, char **argv)
 		if (changeuser && initgroups(changeuser, gid))
 			eerrorx("%s: initgroups (%s, %d)",
 			    applet, changeuser, gid);
-#ifdef HAVE_CAP
+#ifdef __linux__
 		if (uid && cap_setuid(uid))
 #else
 		if (uid && setuid(uid))
@@ -966,7 +966,7 @@ int main(int argc, char **argv)
 		/* Close any fd's to the passwd database */
 		endpwent();
 
-#ifdef HAVE_CAP
+#ifdef __linux__
 		if (cap_iab != NULL) {
 			i = cap_iab_set_proc(cap_iab);
 

--- a/src/supervise-daemon/meson.build
+++ b/src/supervise-daemon/meson.build
@@ -1,6 +1,6 @@
 executable('supervise-daemon',
   ['supervise-daemon.c', pipes_c, misc_c, plugin_c, schedules_c, usage_c, version_h],
-  c_args : [cc_branding_flags, cc_pam_flags, cc_cap_flags, cc_selinux_flags],
+  c_args : [cc_branding_flags, cc_pam_flags, cc_selinux_flags],
   link_with: [libeinfo, librc],
   dependencies: [dl_dep, pam_dep, cap_dep, util_dep, selinux_dep],
   include_directories: [incdir, einfo_incdir, rc_incdir],

--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -54,7 +54,7 @@
 static struct pam_conv conv = { NULL, NULL};
 #endif
 
-#ifdef HAVE_CAP
+#ifdef __linux__
 #include <sys/capability.h>
 #endif
 
@@ -182,7 +182,7 @@ static int fifo_fd = 0;
 static char *pidfile = NULL;
 static char *svcname = NULL;
 static bool verbose = false;
-#ifdef HAVE_CAP
+#ifdef __linux__
 static cap_iab_t cap_iab = NULL;
 static unsigned secbits = 0;
 #endif
@@ -443,7 +443,7 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 		eerrorx("%s: unable to set groupid to %d", applet, gid);
 	if (changeuser && initgroups(changeuser, gid))
 		eerrorx("%s: initgroups (%s, %d)", applet, changeuser, gid);
-#ifdef HAVE_CAP
+#ifdef __linux__
 	if (uid && cap_setuid(uid))
 #else
 	if (uid && setuid(uid))
@@ -453,7 +453,7 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 	/* Close any fd's to the passwd database */
 	endpwent();
 
-#ifdef HAVE_CAP
+#ifdef __linux__
 	if (cap_iab != NULL) {
 		i = cap_iab_set_proc(cap_iab);
 
@@ -883,7 +883,7 @@ int main(int argc, char **argv)
 			break;
 
 		case LONGOPT_CAPABILITIES:
-#ifdef HAVE_CAP
+#ifdef __linux__
 			cap_iab = cap_iab_from_text(optarg);
 			if (cap_iab == NULL)
 				eerrorx("Could not parse iab: %s", strerror(errno));
@@ -893,7 +893,7 @@ int main(int argc, char **argv)
 			break;
 
         case LONGOPT_SECBITS:
-#ifdef HAVE_CAP
+#ifdef __linux__
 			if (*optarg == '\0')
 				eerrorx("Secbits are empty");
 


### PR DESCRIPTION
For linux systems, libcap is a lightweight dependency. Also, making it optional requires that service scripts be written to deal with the possibility that capabilities are not supported.

This fixes #739.

X-Gemtoo-Bug: https://bugs.gentoo.org/939543