### PR TITLE
librc: fix getline return value check

### DIFF
--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -142,7 +142,7 @@ rc_proc_getent(const char *ent RC_UNUSED)
 		return NULL;
 
 	i = 0;
-	if ((size = getline(&proc, &i, fp) == -1)) {
+	if ((size = getline(&proc, &i, fp)) == -1) {
 		free(proc);
 		return NULL;
 	}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/939758
Fixes: 0702a064a93af9a98e6954e035867882778f4268