### PR TITLE
When manually marking service status, use SIGUSR1 to skip default.

### DIFF
--- a/src/mark_service/mark_service.c
+++ b/src/mark_service/mark_service.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
 	if (ok && svcname && strcmp(svcname, service) == 0) {
 		openrc_pid = getenv("RC_OPENRC_PID");
 		if (openrc_pid && sscanf(openrc_pid, "%d", &pid) == 1)
-			if (kill(pid, SIGHUP) != 0)
+			if (kill(pid, SIGUSR1) != 0)
 				eerror("%s: failed to signal parent %d: %s",
 				    applet, pid, strerror(errno));
 

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -92,7 +92,7 @@ static RC_STRINGLIST *use_services;
 static RC_STRINGLIST *want_services;
 static RC_HOOK hook_out;
 static int exclusive_fd = -1, master_tty = -1;
-static bool sighup, in_background, deps, dry_run;
+static bool sighup, sigusr1, in_background, deps, dry_run;
 static pid_t service_pid;
 static int signal_pipe[2] = { -1, -1 };
 
@@ -115,6 +115,10 @@ handle_signal(int sig)
 	switch (sig) {
 	case SIGHUP:
 		sighup = true;
+		break;
+
+	case SIGUSR1:
+		sigusr1 = true;
 		break;
 
 	case SIGCHLD:
@@ -802,6 +806,7 @@ static void svc_start_real(void)
 		setenv("IN_BACKGROUND", ibsave, 1);
 	hook_out = RC_HOOK_SERVICE_START_DONE;
 	rc_plugin_run(RC_HOOK_SERVICE_START_NOW, applet);
+	sigusr1 = false;
 	started = (svc_exec("start", NULL) == 0);
 	if (ibsave)
 		unsetenv("IN_BACKGROUND");
@@ -811,7 +816,8 @@ static void svc_start_real(void)
 	else if (!started)
 		eerrorx("ERROR: %s failed to start", applet);
 
-	rc_service_mark(service, RC_SERVICE_STARTED);
+	if (!sigusr1)
+		rc_service_mark(service, RC_SERVICE_STARTED);
 	exclusive_fd = svc_unlock(applet, exclusive_fd);
 	hook_out = RC_HOOK_SERVICE_START_OUT;
 	rc_plugin_run(RC_HOOK_SERVICE_START_DONE, applet);
@@ -1008,6 +1014,7 @@ svc_stop_real(void)
 		setenv("IN_BACKGROUND", ibsave, 1);
 	hook_out = RC_HOOK_SERVICE_STOP_DONE;
 	rc_plugin_run(RC_HOOK_SERVICE_STOP_NOW, applet);
+	sigusr1 = false;
 	stopped = (svc_exec("stop", NULL) == 0);
 	if (ibsave)
 		unsetenv("IN_BACKGROUND");
@@ -1015,11 +1022,12 @@ svc_stop_real(void)
 	if (!stopped)
 		eerrorx("ERROR: %s failed to stop", applet);
 
-	if (in_background)
-		rc_service_mark(service, RC_SERVICE_INACTIVE);
-	else
-		rc_service_mark(service, RC_SERVICE_STOPPED);
-
+	if (!sigusr1) {
+		if (in_background)
+		    rc_service_mark(service, RC_SERVICE_INACTIVE);
+		else
+		    rc_service_mark(service, RC_SERVICE_STOPPED);
+	}
 	hook_out = RC_HOOK_SERVICE_STOP_OUT;
 	rc_plugin_run(RC_HOOK_SERVICE_STOP_DONE, applet);
 	hook_out = 0;
@@ -1275,6 +1283,7 @@ int main(int argc, char **argv)
 
 	/* Setup a signal handler */
 	signal_setup(SIGHUP, handle_signal);
+	signal_setup(SIGUSR1, handle_signal);
 	signal_setup(SIGINT, handle_signal);
 	signal_setup(SIGQUIT, handle_signal);
 	signal_setup(SIGTERM, handle_signal);


### PR DESCRIPTION
PR to address issue #741

Mark