### PR TITLE
remove RC_PREFIX environment variable

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -563,9 +563,6 @@ Default runlevel chosen. Default is default.
 .It Va RC_SYS
 A special variable to describe the system more.
 Possible values are OPENVZ, XENU, XEN0, UML and VSERVER.
-.It Va RC_PREFIX
-In a Gentoo Prefix installation, this variable contains the prefix
-offset. Otherwise it is undefined.
 .It Va RC_UNAME
 The result of `uname -s`.
 .It Va RC_CMD

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -197,10 +197,6 @@ env_config(void)
 	if (sys)
 		setenv("RC_SYS", sys, 1);
 
-#ifdef PREFIX
-	setenv("RC_PREFIX", RC_PREFIX, 1);
-#endif
-
 	/* Some scripts may need to take a different code path if
 	   Linux/FreeBSD, etc
 	   To save on calling uname, we store it in an environment variable */


### PR DESCRIPTION
This was only used in gentoo prefix installations which we no longer support.