### PR TITLE
support for dynamic multiplexing of services

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -547,6 +547,9 @@ sets the following environment variables for use in the service scripts:
 Name of the service.
 .It Va RC_SERVICE
 Full path to the service.
+.It Va RC_SCRIPTDIR
+Full path to the system directory the service lives in. For multiplexed
+services, it is the directory the main service live in.
 .It Va RC_RUNLEVEL
 Current runlevel that OpenRC is in. Note that, in OpenRC, the reboot
 runlevel is mapped to the shutdown runlevel. This was done because most
@@ -584,14 +587,14 @@ should not be unmounted.
 .El
 .Sh FILES
 .Pp
-Configuration files, relative to the location of the service.
+Configuration files, relative to RC_SYSCONFDIR.
 If a file ending with .${RC_RUNLEVEL} exists then we use that instead.
 .Bl -ohang
-.It Pa ../conf.d/${RC_SVCNAME%%.*}
+.It Pa ${RC_SCRIPTDIR}/conf.d/${RC_SVCNAME%%.*}
 multiplexed configuration file.
 Example: if ${RC_SVCNAME} is net.eth1 then look for
-.Pa ../conf.d/net .
-.It Pa ../conf.d/${RC_SVCNAME}
+.Pa ${RC_SCRIPTDIR}/conf.d/net .
+.It Pa ${RC_SCRIPTDIR}/conf.d/${RC_SVCNAME}
 service configuration file.
 .It Pa /etc/rc.conf
 host configuration file.

--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -220,7 +220,7 @@ if [ -d "@SYSCONFDIR@/rc.conf.d" ]; then
 	done
 fi
 
-_conf_d=${RC_SERVICE%/*}/../conf.d
+_conf_d="${RC_SCRIPTDIR}/conf.d"
 # If we're net.eth0 or openvpn.work then load net or openvpn config
 _c=${RC_SVCNAME%%.*}
 if [ -n "$_c" -a "$_c" != "$RC_SVCNAME" ]; then

--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -697,6 +697,7 @@ static const char *const depdirs[] =
 	RC_SVCDIR "/wasinactive",
 	RC_SVCDIR "/failed",
 	RC_SVCDIR "/hotplugged",
+	RC_SVCDIR "/multiplexed",
 	RC_SVCDIR "/daemons",
 	RC_SVCDIR "/options",
 	RC_SVCDIR "/exclusive",

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -267,6 +267,11 @@ bool rc_service_schedule_clear(const char *);
  * @return state of the service */
 RC_SERVICE rc_service_state(const char *);
 
+/*! Dynamically multiplexes a base service into a variant as basename.variant
+ * @param basename or full path of service being multiplexed
+ * @param variant to dynamically multiplex */
+char *rc_service_multiplex(const char *, const char *);
+
 /*! Check if the service started the daemon
  * @param service to check
  * @param exec to check


### PR DESCRIPTION
generate a new directory on the service dir, "multiplexed", which will
hold all the symlinks we generate at runtime, and a new librc function,
"rc_service_multiplex", which takes a basename or service path, and a
variant name, then generated a symlink to the base service from the
multiplex dir.

this allows multiplexing services at runtime, possibly using data
acquired at runtime, such as the name of an user or interface.

this is the second of three patchsets for user services support

as an initial barebones implementation, it's useful only for generating
services without dynamically multiplexed dependencies, as this is what's
needed for bootstrapping the openrc user script in a new session.

a future patch may improve on it, possibly integrating it in dependency
resolution and on the rc-service tool.