### PR TITLE
openrc: Don't use libexec for data cache.

### DIFF
--- a/init.d/consolefont.in
+++ b/init.d/consolefont.in
@@ -61,9 +61,9 @@ start()
 	eend $retval
 
 	# Store the font so we can use it ASAP on boot
-	if [ $retval -eq 0 ] && checkpath -W "$RC_LIBEXECDIR"; then
-		mkdir -p "$RC_LIBEXECDIR"/console
-		setfont -O "$RC_LIBEXECDIR"/console/font
+	if [ $retval -eq 0 ] && checkpath -m 0755 -d "$RC_CACHEDIR" 2>/dev/null; then
+		mkdir -p "$RC_CACHEDIR"/console
+		setfont -O "$RC_CACHEDIR"/console/font
 	fi
 
 	return $retval

--- a/init.d/save-termencoding.in
+++ b/init.d/save-termencoding.in
@@ -23,12 +23,12 @@ start()
 {
 	ebegin "Saving terminal encoding"
 	# Save the encoding for use immediately at boot
-	if checkpath -W "$RC_LIBEXECDIR"; then
-		mkdir -p "$RC_LIBEXECDIR"/console
+	if checkpath -m 0755 -d "$RC_CACHEDIR" 2>/dev/null; then
+		mkdir -p "$RC_CACHEDIR"/console
 		if yesno ${unicode:-yes}; then
-			echo "" > "$RC_LIBEXECDIR"/console/unicode
+			echo "" > "$RC_CACHEDIR"/console/unicode
 		else
-			rm -f "$RC_LIBEXECDIR"/console/unicode
+			rm -f "$RC_CACHEDIR"/console/unicode
 		fi
 	fi
 	eend 0

--- a/init.d/savecache.in
+++ b/init.d/savecache.in
@@ -31,11 +31,11 @@ start()
 
 	ebegin "Saving dependency cache"
 	local rc=0 save=
-	for x in depconfig deptree rc.log shutdowntime; do
+	for x in depconfig deptree rc.log shutdowntime init.d conf.d; do
 		[ -e "$RC_SVCDIR/$x" ] && save="$save $RC_SVCDIR/$x"
 	done
 	if [ -n "$save" ]; then
-		cp -p $save "$RC_CACHEDIR"
+		cp -pr $save "$RC_CACHEDIR"
 		rc=$?
 	fi
 	eend $rc "Unable to save dependency cache"

--- a/init.d/savecache.in
+++ b/init.d/savecache.in
@@ -31,7 +31,7 @@ start()
 
 	ebegin "Saving dependency cache"
 	local rc=0 save=
-	for x in depconfig deptree rc.log shutdowntime softlevel; do
+	for x in depconfig deptree rc.log shutdowntime; do
 		[ -e "$RC_SVCDIR/$x" ] && save="$save $RC_SVCDIR/$x"
 	done
 	if [ -n "$save" ]; then

--- a/init.d/savecache.in
+++ b/init.d/savecache.in
@@ -20,47 +20,27 @@ start()
 			return 1
 		fi
 	fi
-	if [ ! -d "$RC_LIBEXECDIR"/cache ]; then
-		if ! checkpath -W "$RC_LIBEXECDIR"; then
-			eerror "${RC_LIBEXECDIR} is not writable!"
-			eerror "Unable to save dependency cache"
-			if yesno "${RC_GOINGDOWN}"; then
-				return 0
-			fi
-			return 1
-		fi
-		rm -rf "$RC_LIBEXECDIR"/cache
-		if ! mkdir -p "$RC_LIBEXECDIR"/cache; then
-			eerror "Unable to create $RC_LIBEXECDIR/cache"
-			eerror "Unable to save dependency cache"
-			if yesno "${RC_GOINGDOWN}"; then
-				return 0
-			fi
-			return 1
-		fi
-	fi
-	if ! checkpath -W "$RC_LIBEXECDIR"/cache; then
-		eerror "${RC_LIBEXECDIR}/cache is not writable!"
+
+	if ! checkpath -m 0755 -d "$RC_CACHEDIR" 2>/dev/null; then
 		eerror "Unable to save dependency cache"
 		if yesno "${RC_GOINGDOWN}"; then
 			return 0
 		fi
 		return 1
 	fi
+
 	ebegin "Saving dependency cache"
 	local rc=0 save=
 	for x in depconfig deptree rc.log shutdowntime softlevel; do
 		[ -e "$RC_SVCDIR/$x" ] && save="$save $RC_SVCDIR/$x"
 	done
 	if [ -n "$save" ]; then
-		cp -p $save "$RC_LIBEXECDIR"/cache
+		cp -p $save "$RC_CACHEDIR"
 		rc=$?
 	fi
-	if yesno "${RC_GOINGDOWN}"; then
-		if [ $rc -ne 0 ]; then
-			eerror "Unable to save dependency cache"
-		fi
-		eend 0
-	fi
 	eend $rc "Unable to save dependency cache"
+
+	if yesno "${RC_GOINGDOWN}"; then
+		return 0
+	fi
 }

--- a/init.d/termencoding.in
+++ b/init.d/termencoding.in
@@ -41,12 +41,12 @@ start()
 	done
 
 	# Save the encoding for use immediately at boot
-	if checkpath -W "$RC_LIBEXECDIR"; then
-		mkdir -p "$RC_LIBEXECDIR"/console
+	if checkpath -m 0755 -d "$RC_CACHEDIR"; then
+		mkdir -p "$RC_CACHEDIR"/console
 		if yesno ${unicode:-yes}; then
-			echo "" > "$RC_LIBEXECDIR"/console/unicode
+			echo "" > "$RC_CACHEDIR"/console/unicode
 		else
-			rm -f "$RC_LIBEXECDIR"/console/unicode
+			rm -f "$RC_CACHEDIR"/console/unicode
 		fi
 	fi
 

--- a/sh/init-early.sh.Linux.in
+++ b/sh/init-early.sh.Linux.in
@@ -11,6 +11,7 @@
 
 : ${CONSOLE:=/dev/console}
 : ${RC_LIBEXECDIR:=@LIBEXECDIR@}
+: ${RC_CACHEDIR:=/var/cache/rc}
 
 service_present()
 {
@@ -25,7 +26,7 @@ service_present()
 	return 0
 }
 
-if [ -e "$RC_LIBEXECDIR"/console/unicode ]; then
+if [ -e "$RC_CACHEDIR"/console/unicode ]; then
 	termencoding="%G"
 	kmode="-u"
 else
@@ -40,10 +41,10 @@ fi
 if service_present "$RC_DEFAULTLEVEL" consolefont ||
    service_present "$RC_BOOTLEVEL" consolefont; then
 	printf "\033%s" "$termencoding" >"$CONSOLE" 2>/dev/null
-	if [ -r "$RC_LIBEXECDIR"/console/font ] && \
+	if [ -r "$RC_CACHEDIR"/console/font ] && \
 		command -v setfont > /dev/null 2>&1; then
 		[ -c "$CONSOLE" ] && cons="-C $CONSOLE"
-		setfont $cons "$RC_LIBEXECDIR"/console/font 2>/dev/null
+		setfont $cons "$RC_CACHEDIR"/console/font 2>/dev/null
 	fi
 fi
 
@@ -51,8 +52,8 @@ fi
 if service_present "$RC_DEFAULTLEVEL" keymaps ||
    service_present "$RC_BOOTLEVEL" keymaps; then
 	kbd_mode $kmode -C "$CONSOLE" 2>/dev/null
-	if [ -r "$RC_LIBEXECDIR"/console/keymap ]; then
-		loadkeys -q "$RC_LIBEXECDIR"/console/keymap 2>/dev/null
+	if [ -r "$RC_CACHEDIR"/console/keymap ]; then
+		loadkeys -q "$RC_CACHEDIR"/console/keymap 2>/dev/null
 	fi
 fi
 

--- a/sh/init.sh.Linux.in
+++ b/sh/init.sh.Linux.in
@@ -95,8 +95,8 @@ if grep -Eq "[[:space:]]+xenfs$" /proc/filesystems; then
 	eend $?
 fi
 
-if [ -e "$RC_LIBEXECDIR"/cache/softlevel ]; then
-	cp -p "$RC_LIBEXECDIR"/cache/* "$RC_SVCDIR" 2>/dev/null
+if [ -d "$RC_CACHEDIR" ]; then
+	cp -p "$RC_CACHEDIR"/* "$RC_SVCDIR" 2>/dev/null
 fi
 
 echo sysinit >"$RC_SVCDIR"/softlevel

--- a/sh/openrc-user.sh.in
+++ b/sh/openrc-user.sh.in
@@ -3,6 +3,8 @@
 . @LIBEXECDIR@/sh/functions.sh
 
 _sysconf="${XDG_CONFIG_HOME:-${HOME}/.config}/rc"
+_cachedir="${XDG_CACHE_HOME:-${HOME}/.cache}/rc"
+_svcdir="${XDG_RUNTIME_DIR?}/openrc"
 
 for config in "@SYSCONFDIR@/rc.conf" "$_sysconf/rc.conf"; do
 	if [ -e "$config" ] && ! . "$config"; then
@@ -11,9 +13,18 @@ for config in "@SYSCONFDIR@/rc.conf" "$_sysconf/rc.conf"; do
 	fi
 done
 
+mkdir -p "$_svcdir"
+mkdir -p "$_cachedir"
+
 case $1 in
-	start) _runlevel="${rc_default_runlevel:-default}";;
-	stop) _runlevel="shutdown";;
+	start)
+		_runlevel="${rc_default_runlevel:-default}"
+		cp -p "$_cachedir"/* "$_svcdir" 2>/dev/null
+		;;
+	stop)
+		_runlevel="shutdown"
+		cp -p "$_svcdir"/dep* "$_cachedir" 2>/dev/null
+		;;
 	*) eerror "no argument given to $0" && exit 1
 esac
 

--- a/sh/openrc-user.sh.in
+++ b/sh/openrc-user.sh.in
@@ -19,11 +19,11 @@ mkdir -p "$_cachedir"
 case $1 in
 	start)
 		_runlevel="${rc_default_runlevel:-default}"
-		cp -p "$_cachedir"/* "$_svcdir" 2>/dev/null
+		cp -pr "$_cachedir"/* "$_svcdir" 2>/dev/null
 		;;
 	stop)
 		_runlevel="shutdown"
-		cp -p "$_svcdir"/dep* "$_cachedir" 2>/dev/null
+		cp -pr "$_svcdir"/dep* "$_svcdir/init.d" "$_svcdir/conf.d" "$_cachedir" 2>/dev/null
 		;;
 	*) eerror "no argument given to $0" && exit 1
 esac

--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -531,8 +531,7 @@ do_sysinit(void)
 	 * sys */
 	if ((sys = rc_sys()))
 		setenv("RC_SYS", sys, 1);
-	/* force an update of the dependency tree */
-	if ((main_deptree = _rc_deptree_load(1, NULL)) == NULL)
+	if ((main_deptree = _rc_deptree_load(false, NULL)) == NULL)
 		eerrorx("failed to load deptree");
 }
 

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -196,6 +196,23 @@ env_config(void)
 		free(e);
 	}
 
+	if (!rc_is_user()) {
+		setenv("RC_CACHEDIR", "/var/cache/rc", 1);
+	} else {
+		const char *cache_home = getenv("XDG_CACHE_HOME");
+		char *cachedir = NULL;
+
+		if (cache_home)
+			xasprintf(&cachedir, "%s/rc", cache_home);
+		else if ((cache_home = getenv("HOME")))
+			xasprintf(&cachedir, "%s/.cache/rc", cache_home);
+
+		if (cachedir)
+			setenv("RC_CACHEDIR", cachedir, 1);
+
+		free(cachedir);
+	}
+
 	xasprintf(&tmpdir, "%s/tmp", svcdir);
 	e = rc_runlevel_get();
 


### PR DESCRIPTION
Instead, move caches to /var/cache/openrc. If /var is not mounted, cache will not be used and the deptree would be regenerated.