### PR TITLE
rc_ulimit: support multiple limits

### DIFF
--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -39,6 +39,20 @@ sourcex()
 	fi
 }
 
+apply_ulimits()
+{
+	if [ $(( $# % 2 )) -eq 1 ]; then
+		eerror "${RC_SVCNAME}: Invalid RC_ULIMIT setting"
+		return 1
+	fi
+	while [ $# -gt 0 ] ; do
+		if ! ulimit "${1}" "${2}"; then
+			eerror "${RC_SVCNAME}: unable to apply RC_ULIMIT settings"
+		fi
+		shift 2
+	done
+}
+
 sourcex "@LIBEXECDIR@/sh/functions.sh"
 sourcex "@LIBEXECDIR@/sh/rc-functions.sh"
 case $RC_SYS in
@@ -253,12 +267,9 @@ fi
 
 for _cmd; do
 	if [ "$_cmd" != status -a "$_cmd" != describe ]; then
-		# Apply any ulimit defined
-		if [ -n "${rc_ulimit:-$RC_ULIMIT}" ]; then
-			if ! ulimit ${rc_ulimit:-$RC_ULIMIT}; then
-				eerror "${RC_SVCNAME}: unable to apply RC_ULIMIT settings"
-			fi
-		fi
+		# Apply any ulimit(s) defined
+		[ -n "${rc_ulimit:-$RC_ULIMIT}" ] && \
+			apply_ulimits ${rc_ulimit:-$RC_ULIMIT}
 		# Apply cgroups settings if defined
 		if [ "$(command -v cgroup_add_service)" = "cgroup_add_service" ]
 		then

--- a/user-guide.md
+++ b/user-guide.md
@@ -132,8 +132,8 @@ messages to a file), and a few others.
 
 # ulimit and CGroups
 
-Setting `ulimit` and `nice` values per service can be done through the
-`rc_ulimit` variable.
+Setting `ulimit` values per service can be done through the `rc_ulimit`
+variable.
 
 Under Linux, OpenRC can use cgroups for process management as well. Once
 the kernel is configured appropriately, the `rc_cgroup_mode` setting in


### PR DESCRIPTION
This adds support for multiple limits in rc_ulimit as identified in  https://github.com/OpenRC/openrc/issues/399#issuecomment-810461921

The inconsistent aspects of the ulimit shell builtin ([#399](https://github.com/OpenRC/openrc/issues/399)) still remain, but it works well until setrlimit is implemented.

I have also updated the incorrect documentation in #701: niceness is not settable here, only RLIMIT_NICE, and only when using bash's ulimit.

Mark