### PR TITLE
consolefont: change parameter order for compatibility with kbd >=2.7

### DIFF
--- a/init.d/consolefont.in
+++ b/init.d/consolefont.in
@@ -52,7 +52,7 @@ start()
 	[ -d /dev/vc ] && ttydev=/dev/vc/
 	x=1
 	while [ $x -le $ttyn ]; do
-		if ! setfont $consolefont $param -C $ttydev$x >/dev/null; then
+		if ! setfont $param -C $ttydev$x $consolefont >/dev/null; then
 			retval=1
 			break
 		fi


### PR DESCRIPTION
The newly released kbd 2.7 includes a rewrite of the setfont argument parser, with this rewritten parser command-line option need to be passed **before** the font. Otherwise, the parameters will be interpreted as font names. Without this patch, this causes the consolefont service to fail with the following error message:

	setfont: Unable to find file: -C

Note that the `setfont(8)` man page still recommends passing -C after the font name. I am not sure if this is a documentation or implementation issue.

See: https://github.com/legionus/kbd/commit/aed486b760ccc7cdb0ae9a36b428bded6ea132c7