### PR TITLE
init.d/{local,net}mount: Allow lxc keyword.

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -16,7 +16,7 @@ depend()
 	need fsck root
 	use lvm modules
 	after clock lvm modules
-	keyword -docker -podman -jail -lxc -prefix -systemd-nspawn -vserver
+	keyword -docker -podman -jail -prefix -systemd-nspawn -vserver
 }
 
 start()

--- a/init.d/netmount.in
+++ b/init.d/netmount.in
@@ -26,7 +26,7 @@ depend()
 	use afc-client amd openvpn
 	use dns
 	use root
-	keyword -docker -podman -jail -lxc -prefix -systemd-nspawn -vserver
+	keyword -docker -podman -jail -prefix -systemd-nspawn -vserver
 }
 
 start()


### PR DESCRIPTION
lxc expects /etc/fstab to be respected, and already patches openrc to enable localmount on their alpine image: https://github.com/lxc/lxc-ci/pull/494

Fixes: https://bugs.gentoo.org/898904
Fixes: https://bugs.gentoo.org/947111