### PR TITLE
Adding back Gentoo Prefix support

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -563,6 +563,9 @@ Default runlevel chosen. Default is default.
 .It Va RC_SYS
 A special variable to describe the system more.
 Possible values are OPENVZ, XENU, XEN0, UML and VSERVER.
+.It Va RC_PREFIX
+In a Gentoo Prefix installation, this variable contains the prefix
+offset. Otherwise it is an empty string.
 .It Va RC_UNAME
 The result of `uname -s`.
 .It Va RC_CMD

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project('OpenRC', 'c',
     'c_std=c99',
     'prefix=/usr',
     'sbindir=/sbin',
+    'gentooprefix=',
     'warning_level=3',
     ],
   meson_version : '>=0.62.0'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,8 @@ option('pkg_prefix', type : 'string',
   description : 'default location where packages are installed')
 option('pkgconfig', type : 'boolean',
   description : 'build PKGConfig files')
+option('gentooprefix', type : 'string',
+  description : 'the Gentoo prefix')
 option('selinux', type : 'feature', value : 'auto',
   description : 'enable SELinux support')
 option('shell', type : 'string', value : '/bin/sh',

--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -235,9 +235,6 @@ get_systype(void)
 static const char *
 detect_prefix(const char *systype)
 {
-#ifdef PREFIX
-	return RC_SYS_PREFIX;
-#else
 	if (systype) {
 		if (strcmp(systype, RC_SYS_NONE) == 0)
 			return NULL;
@@ -246,7 +243,6 @@ detect_prefix(const char *systype)
 	}
 
 	return NULL;
-#endif
 }
 
 static const char *

--- a/src/librc/meson.build
+++ b/src/librc/meson.build
@@ -4,6 +4,7 @@ rc_h_conf_data.set('RC_PLUGINDIR', pluginsdir)
 rc_h_conf_data.set('LOCAL_PREFIX', local_prefix)
 rc_h_conf_data.set('PKG_PREFIX', pkg_prefix)
 rc_h_conf_data.set('SYSCONFDIR', get_option('sysconfdir'))
+rc_h_conf_data.set('GENTOOPREFIX', get_option('gentooprefix'))
 
 librc_version = '1'
 

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -22,14 +22,12 @@
 extern "C" {
 #endif
 
-#define RC_PREFIX "@PREFIX@"
+#define RC_PREFIX "@GENTOOPREFIX@"
 #define RC_SYSCONFDIR		"@SYSCONFDIR@"
 #define RC_LIBEXECDIR           "@RC_LIBEXECDIR@"
-#if defined(PREFIX)
-#define RC_SVCDIR               RC_LIBEXECDIR "/init.d"
-#elif defined(__linux__) || (defined(__FreeBSD_kernel__) && \
+#if defined(__linux__) || (defined(__FreeBSD_kernel__) && \
 		defined(__GLIBC__)) || defined(__GNU__)
-#define RC_SVCDIR               "/run/openrc"
+#define RC_SVCDIR               RC_PREFIX "/run/openrc"
 #else
 #define RC_SVCDIR               RC_LIBEXECDIR "/init.d"
 #endif

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -215,6 +215,8 @@ env_config(void)
 	if (sys)
 		setenv("RC_SYS", sys, 1);
 
+	setenv("RC_PREFIX", RC_PREFIX, 1);
+
 	/* Some scripts may need to take a different code path if
 	   Linux/FreeBSD, etc
 	   To save on calling uname, we store it in an environment variable */


### PR DESCRIPTION
This reverts 50a338b96a5a6e6774c39dbff961426ccb1b4aa6 and continues https://github.com/OpenRC/openrc/pull/672

@heroxbd and I use openrc inside Gentoo Prefix to manage services, so we'd like to see this feature back 