### PR TITLE
init.d/swap: start after localmount

### DIFF
--- a/init.d/swap.in
+++ b/init.d/swap.in
@@ -11,8 +11,7 @@
 
 depend()
 {
-	after clock root
-	before localmount
+	after clock root localmount
 	keyword -docker -podman -jail -lxc -openvz -prefix -systemd-nspawn -vserver
 }
 


### PR DESCRIPTION
A swapfile can be placed on any partition, not just on root. However because swap was started before localmount which is supposed to mount any additional partitions swap would fail whenever the swapfile was located on one of these additional partitions.
Making sure localmount ran before means the swapfile can be found and activated successfully in all cases.