### PR TITLE
docs: fix typos/grammar in user-guide.md

### DIFF
--- a/user-guide.md
+++ b/user-guide.md
@@ -199,10 +199,10 @@ used to store state for openrc itself and the services it runs.
 
 OpenRC supports automatically managing user service sessions via PAM modules.
 
-Add `pam_openrc.so` to the pam configuration of the prefered login method
+Add `pam_openrc.so` to the pam configuration of the preferred login method
 (i.e. login, ssh), and set up the pam configuration for `openrc-user` as to
 a similar configuration as a usual login session (if XDG_RUNTIME_DIR is set
-via pam modules, it should be include, as well as anything required for a
+via pam modules, it should be included, as well as anything required for a
 usual user session).
 
 ## Launching at boot

--- a/user-guide.md
+++ b/user-guide.md
@@ -189,7 +189,7 @@ and similarly options set in ~/.config/rc/rc.conf overrides /etc/rc.conf.
 
 Runlevels are kept in ~/.config/rc/runlevels.
 
-`openrc` and all `rc-*` tools provie a --user/-U flag to operate with user-mode
+`openrc` and all `rc-*` tools provide a --user/-U flag to operate with user-mode
 services and runlevels.
 
 The XDG_RUNTIME_DIR variable must be set before calling openrc --user, as it's

--- a/user-guide.md
+++ b/user-guide.md
@@ -201,8 +201,8 @@ OpenRC supports automatically managing user service sessions via PAM modules.
 
 Add `pam_openrc.so` to the pam configuration of the prefered login method
 (i.e. login, ssh), and set up the pam configuration for `openrc-user` as to
-a similar configuration as an usual login session (if XDG_RUNTIME_DIR is set
-via pam modules, it should be include, as well as anything required for an
+a similar configuration as a usual login session (if XDG_RUNTIME_DIR is set
+via pam modules, it should be include, as well as anything required for a
 usual user session).
 
 ## Launching at boot


### PR DESCRIPTION
I noticed some typos/grammar issues while reading the docs, here's a fix :)