### PR TITLE
Allow only building the pam_openrc module for user services

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,8 @@ else
   cc_pam_flags = []
 endif
 
-if not pam_dep.found() and get_option('pam')
+pam_required = get_option('pam') or get_option('pam_user')
+if not pam_dep.found() and pam_required
   error('Pam was requested but could not be located')
 endif
 
@@ -98,12 +99,12 @@ selinux_dep = dependency('libselinux', required : get_option('selinux'))
 pam_misc_dep = []
 if selinux_dep.found()
   cc_selinux_flags = '-DHAVE_SELINUX'
-  if pam_dep.found() and get_option('pam')
+  if pam_dep.found() and pam_required
     pam_misc_dep = dependency('pam_misc', required: false)
     if not pam_misc_dep.found()
       pam_misc_dep = cc.find_library('pam_misc', required: false)
     endif
-    if not pam_misc_dep.found() and get_option('pam')
+    if not pam_misc_dep.found() and pam_required
       error('Pam was requested but could not be located')
     endif
   else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,8 @@ option('os', type : 'combo',
   description : 'Operating System (autodetected if not specified)')
 option('pam', type : 'boolean',
   description : 'enable PAM support')
+option('pam_user', type : 'boolean',
+  description : 'only enable PAM support for the pam_openrc user services module')
 option('pkg_prefix', type : 'string',
   description : 'default location where packages are installed')
 option('pkgconfig', type : 'boolean',

--- a/src/pam_openrc/meson.build
+++ b/src/pam_openrc/meson.build
@@ -1,4 +1,4 @@
-if get_option('pam') and pam_dep.found()
+if (get_option('pam') or get_option('pam_user')) and pam_dep.found()
   shared_module('pam_openrc',
     ['pam_openrc.c', misc_c, version_h],
     c_args : [cc_branding_flags],


### PR DESCRIPTION
This is useful for Alpine's OpenRC package where we build OpenRC without PAM support (since PAM is not supported by the Alpine base system, i.e. BusyBox) but want to provide the pam_openrc module as a standalone subpackage for people wanting to use OpenRC user services with the autostarting feature.