### PR TITLE
init.d/*: Quote the argument of ":" commands

### DIFF
--- a/init.d/adjkerntz.in
+++ b/init.d/adjkerntz.in
@@ -14,7 +14,7 @@ extra_commands="save"
 description="Sets the local clock to UTC or Local Time."
 description_save="Saves the current time in the BIOS."
 
-: ${clock:=${CLOCK:-UTC}}
+: "${clock:=${CLOCK:-UTC}}"
 if [ "$clock" = "UTC" ]; then
 	utc="UTC"
 else

--- a/init.d/bootmisc.in
+++ b/init.d/bootmisc.in
@@ -17,8 +17,8 @@ depend()
 	keyword -prefix -timeout
 }
 
-: ${wipe_tmp:=${WIPE_TMP:-yes}}
-: ${log_dmesg:=${LOG_DMESG:-yes}}
+: "${wipe_tmp:=${WIPE_TMP:-yes}}"
+: "${log_dmesg:=${LOG_DMESG:-yes}}"
 
 cleanup_tmp_dir()
 {

--- a/init.d/hostid.in
+++ b/init.d/hostid.in
@@ -10,7 +10,7 @@
 # except according to the terms contained in the LICENSE file.
 
 extra_commands="reset"
-: ${hostid_file:=/etc/hostid}
+: "${hostid_file:=/etc/hostid}"
 
 depend()
 {

--- a/init.d/hwclock.in
+++ b/init.d/hwclock.in
@@ -15,10 +15,10 @@ description="Sets the local clock to UTC or Local Time."
 description_save="Saves the current time in the BIOS."
 description_show="Displays the current time in the BIOS."
 
-: ${clock_adjfile:=${CLOCK_ADJFILE}}
-: ${clock_args:=${CLOCK_OPTS}}
-: ${clock_systohc:=${CLOCK_SYSTOHC}}
-: ${clock:=${CLOCK:-UTC}}
+: "${clock_adjfile:=${CLOCK_ADJFILE}}"
+: "${clock_args:=${CLOCK_OPTS}}"
+: "${clock_systohc:=${CLOCK_SYSTOHC}}"
+: "${clock:=${CLOCK:-UTC}}"
 if [ "$clock" = "UTC" ]; then
 	utc="UTC"
 	utc_cmd="--utc"

--- a/init.d/pf.in
+++ b/init.d/pf.in
@@ -10,7 +10,7 @@
 # except according to the terms contained in the LICENSE file.
 
 name="Packet Filter"
-: ${pf_conf:=${pf_rules:-/etc/pf.conf}}
+: "${pf_conf:=${pf_rules:-/etc/pf.conf}}"
 required_files=$pf_conf
 
 extra_commands="checkconfig showstatus"

--- a/init.d/save-termencoding.in
+++ b/init.d/save-termencoding.in
@@ -10,7 +10,7 @@
 description="Configures terminal encoding."
 
 ttyn=${rc_tty_number:-${RC_TTY_NUMBER:-12}}
-: ${unicode:=${UNICODE}}
+: "${unicode:=${UNICODE}}"
 
 depend()
 {

--- a/init.d/termencoding.in
+++ b/init.d/termencoding.in
@@ -12,7 +12,7 @@
 description="Configures terminal encoding."
 
 ttyn=${rc_tty_number:-${RC_TTY_NUMBER:-12}}
-: ${unicode:=${UNICODE}}
+: "${unicode:=${UNICODE}}"
 
 depend()
 {

--- a/init.d/urandom.in
+++ b/init.d/urandom.in
@@ -9,7 +9,7 @@
 # This file may not be copied, modified, propagated, or distributed
 # except according to the terms contained in the LICENSE file.
 
-: ${urandom_seed:=${URANDOM_SEED:-/var/lib/misc/random-seed}}
+: "${urandom_seed:=${URANDOM_SEED:-/var/lib/misc/random-seed}}"
 description="Initializes the random number generator."
 
 depend()


### PR DESCRIPTION
This avoids globbing, see: https://www.shellcheck.net/wiki/SC2223