### PR TITLE
shared/misc: fix types on close_range wrapper

### DIFF
--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -584,8 +584,8 @@ bool ready_wait(const char *applet, struct ready ready)
 }
 
 #ifndef HAVE_CLOSE_RANGE
-static inline int close_range(int first RC_UNUSED,
-			      int last RC_UNUSED,
+static inline int close_range(unsigned int first RC_UNUSED,
+			      unsigned int last RC_UNUSED,
 			      unsigned int flags RC_UNUSED)
 {
 #ifdef SYS_close_range


### PR DESCRIPTION
The syscall expects unsigned integers.  Notably, if this wrapper is called, `UINT_MAX` is passed as `last`, and conversion from unsigned to signed is implementation-defined.