### PR TITLE
librc/run/shutdown: precalc strlen moved out of bounds loop

### DIFF
--- a/src/librc/librc-daemon.c
+++ b/src/librc/librc-daemon.c
@@ -158,6 +158,7 @@ rc_find_pids(const char *exec, const char *const *argv, uid_t uid, pid_t pid)
 			my_ns[0] = '\0';
 	}
 
+	size_t len_my_ns = strlen(my_ns);
 	while ((entry = readdir(procdir)) != NULL) {
 		if (sscanf(entry->d_name, "%d", &p) != 1)
 			continue;
@@ -172,7 +173,7 @@ rc_find_pids(const char *exec, const char *const *argv, uid_t uid, pid_t pid)
 				proc_ns[0] = '\0';
 		}
 		free(buffer);
-		if (pid == 0 && strlen(my_ns) && strlen (proc_ns) && strcmp(my_ns, proc_ns))
+		if (pid == 0 && len_my_ns && strlen (proc_ns) && strcmp(my_ns, proc_ns))
 			continue;
 		if (uid) {
 			xasprintf(&buffer, "/proc/%d", p);

--- a/src/librc/librc-misc.c
+++ b/src/librc/librc-misc.c
@@ -224,8 +224,8 @@ static void rc_config_set_value(RC_STRINGLIST *config, char *value)
 	replaced = false;
 	/* In shells the last item takes precedence, so we need to remove
 	   any prior values we may already have */
+	i = strlen(entry);
 	TAILQ_FOREACH(cline, config, entries) {
-		i = strlen(entry);
 		if (strncmp(entry, cline->value, i) == 0 && cline->value[i] == '=') {
 			/* We have a match now - to save time we directly replace it */
 			free(cline->value);

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -308,6 +308,9 @@ write_prefix(const char *buffer, size_t bytes, bool *prefixed)
 	else
 		ewarnv("Couldn't open the prefix lock, please make sure you have enough permissions");
 
+	size_t len_ec = strlen(ec);
+	size_t len_prefix = strlen(prefix);
+	size_t len_ec_normal = strlen(ec_normal);
 	for (i = 0; i < bytes; i++) {
 		/* We don't prefix eend calls (cursor up) */
 		if (buffer[i] == '\033' && !*prefixed) {
@@ -320,9 +323,9 @@ write_prefix(const char *buffer, size_t bytes, bool *prefixed)
 		}
 
 		if (!*prefixed) {
-			ret += write(fd, ec, strlen(ec));
-			ret += write(fd, prefix, strlen(prefix));
-			ret += write(fd, ec_normal, strlen(ec_normal));
+			ret += write(fd, ec, len_ec);
+			ret += write(fd, prefix, len_prefix);
+			ret += write(fd, ec_normal, len_ec_normal);
 			ret += write(fd, "|", 1);
 			*prefixed = true;
 		}

--- a/src/openrc-shutdown/broadcast.c
+++ b/src/openrc-shutdown/broadcast.c
@@ -144,10 +144,11 @@ void broadcast(char *text)
 
 	setutxent();
 
+	size_t len_path_dev = strlen(_PATH_DEV);
 	while ((utmp = getutxent()) != NULL) {
 		if (utmp->ut_type != USER_PROCESS || utmp->ut_user[0] == 0)
 			continue;
-		if (strncmp(utmp->ut_line, _PATH_DEV, strlen(_PATH_DEV)) == 0)
+		if (strncmp(utmp->ut_line, _PATH_DEV, len_path_dev) == 0)
 			xasprintf(&term, "%s", utmp->ut_line);
 		else
 			xasprintf(&term, "%s%s", _PATH_DEV, utmp->ut_line);


### PR DESCRIPTION
@navi-desu,

Example with clang-19 -O2

Before:

![before](https://github.com/user-attachments/assets/0334f713-b32f-4d75-9609-c0ccb9f9f230)

After:

![after](https://github.com/user-attachments/assets/631650fb-3d20-4900-ba08-603fbcd10811)