### PR TITLE
openrc-run: Fix loading of user configs for system-supplied user services

### DIFF
--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -234,9 +234,9 @@ if [ -d "@SYSCONFDIR@/rc.conf.d" ]; then
 	done
 fi
 
-_usr_conf_d=${XDG_CONFIG_HOME:-${HOME}/.config}/rc
+_usr_conf=${XDG_CONFIG_HOME:-${HOME}/.config}/rc
 if yesno "$RC_USER_SERVICES"; then
-	sourcex -e "$_usr_conf_d/rc.conf"
+	sourcex -e "$_usr_conf/rc.conf"
 fi
 
 _conf_d=${RC_SERVICE%/*}/../conf.d
@@ -255,12 +255,12 @@ if ! sourcex -e "$_conf_d/$RC_SVCNAME.$RC_RUNLEVEL"; then
 fi
 unset _conf_d
 
-if yesno "$RC_USER_SERVICES" && [ $_usr_conf_d != ${RC_SERVICE%/*} ]; then
-	if ! sourcex -e "$_usr_conf_d/$RC_SVCNAME.$RC_RUNLEVEL"; then
-		sourcex -e "$_usr_conf_d/$RC_SVCNAME"
+if yesno "$RC_USER_SERVICES" && [ "$_usr_conf/init.d" != "${RC_SERVICE%/*}" ]; then
+	if ! sourcex -e "$_usr_conf/conf.d/$RC_SVCNAME.$RC_RUNLEVEL"; then
+		sourcex -e "$_usr_conf/conf.d/$RC_SVCNAME"
 	fi
 fi
-unset _usr_conf_d
+unset _usr_conf
 
 # load service supervisor functions
 sourcex "@LIBEXECDIR@/sh/runit.sh"


### PR DESCRIPTION
Without this patch, OpenRC loads user configuration files for system-supplied services from `~/.config/rc/$SERVICE` instead of `~/.config/rc/conf.d/$SERVICE`. Since the latter is [documented in the user-guide](https://github.com/OpenRC/openrc/blob/0.60.1/user-guide.md#user-services----experimental), and used for user services not supplied by the system, I believe it to be the correct location.

Note that the `_usr_conf_d` variable is probably a bit inappropriately named as the similarly named `_conf_d` points to the system conf.d directory while `_usr_conf_d` points to the base rc configuration directory. Might be worthwhile to rename it…

This is a fixup for ae9d743207f27481efe2c80593eea51cd8742ab2.