### PR TITLE
s-s-d, supervise-daemon: handle "/dev/stderr" for output_log

### DIFF
--- a/man/start-stop-daemon.8
+++ b/man/start-stop-daemon.8
@@ -150,6 +150,8 @@ The logfile Must be an absolute pathname, but relative to the path
 optionally given with
 .Fl r , -chroot .
 The logfile can also be a named pipe.
+The value "/dev/stderr" is treated specially to redirect the process's stdout
+to stderr.
 .It Fl 2 , -stderr Ar logfile
 Redirect the standard error of the process to logfile when started with
 .Fl background .

--- a/man/supervise-daemon.8
+++ b/man/supervise-daemon.8
@@ -159,6 +159,8 @@ Redirect the standard output of the process to logfile.
 Must be an absolute pathname, but relative to the path optionally given with
 .Fl r , -chroot .
 The logfile can also be a named pipe.
+The value "/dev/stderr" is treated specially to redirect the process's stdout
+to stderr.
 .It Fl 2 , -stderr Ar logfile
 The same thing as
 .Fl 1 , -stdout

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -1071,7 +1071,7 @@ int main(int argc, char **argv)
 		stdin_fd = devnull_fd;
 		stdout_fd = devnull_fd;
 		stderr_fd = devnull_fd;
-		if (redirect_stdout) {
+		if (redirect_stdout && strcmp(redirect_stdout, "/dev/stderr") != 0) {
 			if ((stdout_fd = open(redirect_stdout,
 				    O_WRONLY | O_CREAT | O_APPEND,
 				    S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)) == -1)
@@ -1099,6 +1099,9 @@ int main(int argc, char **argv)
 				    " for stderr `%s': %s",
 				    applet, stderr_process, strerror(errno));
 		}
+
+		if (strcmp(redirect_stdout, "/dev/stderr") == 0)
+			stdout_fd = stderr_fd;
 
 		if (background)
 			dup2(stdin_fd, STDIN_FILENO);

--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -554,7 +554,7 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 	stdin_fd = devnull_fd;
 	stdout_fd = devnull_fd;
 	stderr_fd = devnull_fd;
-	if (redirect_stdout) {
+	if (redirect_stdout && strcmp(redirect_stdout, "/dev/stderr") != 0) {
 		if ((stdout_fd = open(redirect_stdout,
 			    O_WRONLY | O_CREAT | O_APPEND,
 			    S_IRUSR | S_IWUSR)) == -1)
@@ -582,6 +582,9 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 			    " for stderr `%s': %s",
 			    applet, stderr_process, strerror(errno));
 	}
+
+	if (strcmp(redirect_stdout, "/dev/stderr") == 0)
+		stdout_fd = stderr_fd;
 
 	dup2(stdin_fd, STDIN_FILENO);
 	if (redirect_stdout || stdout_process || rc_yesno(getenv("EINFO_QUIET")))


### PR DESCRIPTION
useful to be able to redirect both standard output and error into a single logger process, which currently isn't quite possible.