### PR TITLE
librc: use dirfd and *at functions.

### DIFF
--- a/src/librc/librc-daemon.c
+++ b/src/librc/librc-daemon.c
@@ -329,17 +329,17 @@ rc_find_pids(const char *exec, const char *const *argv, uid_t uid, pid_t pid)
 #endif
 
 static bool
-_match_daemon(const char *path, const char *file, RC_STRINGLIST *match)
+_match_daemon(const char *svcname, const char *instance, RC_STRINGLIST *match)
 {
 	char *line = NULL;
 	size_t len = 0;
-	char *ffile = NULL;
 	FILE *fp;
 	RC_STRING *m;
+	char *daemon;
 
-	xasprintf(&ffile, "%s/%s", path, file);
-	fp = fopen(ffile, "r");
-	free(ffile);
+	xasprintf(&daemon, "%s/%s", svcname, instance);
+	fp = do_fopenat(rc_dirfd(RC_DIR_DAEMONS), daemon, O_RDONLY);
+	free(daemon);
 
 	if (!fp)
 		return false;
@@ -393,7 +393,6 @@ rc_service_daemon_set(const char *service, const char *exec,
     const char *const *argv,
     const char *pidfile, bool started)
 {
-	char *dirpath = NULL;
 	char *file = NULL;
 	int nfiles = 0;
 	char oldfile[PATH_MAX] = { '\0' };
@@ -403,23 +402,22 @@ rc_service_daemon_set(const char *service, const char *exec,
 	RC_STRINGLIST *match, *renamelist;
 	int i = 0;
 	FILE *fp;
+	const char *base = basename_c(service);
 
 	if (!exec && !pidfile) {
 		errno = EINVAL;
 		return false;
 	}
 
-	xasprintf(&dirpath, "%s/daemons/%s", rc_svcdir(), basename_c(service));
-
 	/* Regardless, erase any existing daemon info */
-	if ((dp = opendir(dirpath))) {
+	if ((dp = do_opendirat(rc_dirfd(RC_DIR_DAEMONS), base))) {
 		match = _match_list(exec, argv, pidfile);
 		renamelist = rc_stringlist_new();
 		while ((d = readdir(dp))) {
 			if (d->d_name[0] == '.')
 				continue;
 
-			xasprintf(&file, "%s/%s", dirpath, d->d_name);
+			xasprintf(&file, "%s/daemons/%s/%s", rc_svcdir(), base, d->d_name);
 			if (rc_stringlist_find(renamelist, file)) {
 				free(file);
 				continue;
@@ -428,7 +426,7 @@ rc_service_daemon_set(const char *service, const char *exec,
 			nfiles++;
 
 			if (!*oldfile) {
-				if (_match_daemon(dirpath, d->d_name, match)) {
+				if (_match_daemon(base, d->d_name, match)) {
 					unlink(file);
 					strlcpy(oldfile, file, sizeof(oldfile));
 					nfiles--;
@@ -448,30 +446,29 @@ rc_service_daemon_set(const char *service, const char *exec,
 	}
 
 	/* Now store our daemon info */
-	if (started) {
-		if (mkdir(dirpath, 0755) == 0 || errno == EEXIST) {
-			xasprintf(&file, "%s/%03d", dirpath, nfiles + 1);
-			if ((fp = fopen(file, "w"))) {
-				fprintf(fp, "exec=");
-				if (exec)
-					fprintf(fp, "%s", exec);
-				while (argv && argv[i]) {
-					fprintf(fp, "\nargv_%d=%s", i, argv[i]);
-					i++;
-				}
-				fprintf(fp, "\npidfile=");
-				if (pidfile)
-					fprintf(fp, "%s", pidfile);
-				fprintf(fp, "\n");
-				fclose(fp);
-				retval = true;
-			}
-			free(file);
-		}
-	} else
-		retval = true;
+	if (!started)
+		return true;
 
-	free(dirpath);
+	if (mkdirat(rc_dirfd(RC_DIR_DAEMONS), base, 0755) == 0 || errno == EEXIST) {
+		xasprintf(&file, "%s/daemons/%s/%03d", rc_svcdir(), base, nfiles + 1);
+		if ((fp = fopen(file, "w"))) {
+			fprintf(fp, "exec=");
+			if (exec)
+				fprintf(fp, "%s", exec);
+			while (argv && argv[i]) {
+				fprintf(fp, "\nargv_%d=%s", i, argv[i]);
+				i++;
+			}
+			fprintf(fp, "\npidfile=");
+			if (pidfile)
+				fprintf(fp, "%s", pidfile);
+			fprintf(fp, "\n");
+			fclose(fp);
+			retval = true;
+		}
+		free(file);
+	}
+
 	return retval;
 }
 
@@ -479,7 +476,7 @@ bool
 rc_service_started_daemon(const char *service,
     const char *exec, const char *const *argv, int indx)
 {
-	char *dirpath = NULL;
+	const char *base = basename_c(service);
 	char *file = NULL;
 	RC_STRINGLIST *match;
 	bool retval = false;
@@ -489,38 +486,31 @@ rc_service_started_daemon(const char *service,
 	if (!service || !exec)
 		return false;
 
-	xasprintf(&dirpath, "%s/daemons/%s", rc_svcdir(), basename_c(service));
 	match = _match_list(exec, argv, NULL);
 
 	if (indx > 0) {
 		xasprintf(&file, "%03d", indx);
-		retval = _match_daemon(dirpath, file, match);
+		retval = _match_daemon(base, file, match);
 		free(file);
-	} else {
-		if ((dp = opendir(dirpath))) {
-			while ((d = readdir(dp))) {
-				if (d->d_name[0] == '.')
-					continue;
-				retval = _match_daemon(dirpath, d->d_name, match);
-				if (retval)
-					break;
-			}
-			closedir(dp);
+	} else if ((dp = do_opendirat(rc_dirfd(RC_DIR_DAEMONS), base))) {
+		while ((d = readdir(dp))) {
+			if (d->d_name[0] == '.')
+				continue;
+			if ((retval = _match_daemon(base, d->d_name, match)))
+				break;
 		}
+		closedir(dp);
 	}
 
 	rc_stringlist_free(match);
-	free(dirpath);
 	return retval;
 }
 
 bool
 rc_service_daemons_crashed(const char *service)
 {
-	char dirpath[PATH_MAX];
 	DIR *dp;
 	struct dirent *d;
-	char *path = dirpath;
 	FILE *fp;
 	char *line = NULL;
 	size_t len = 0;
@@ -541,20 +531,14 @@ rc_service_daemons_crashed(const char *service)
 	char *ch_root;
 	char *spidfile;
 
-	path += snprintf(dirpath, sizeof(dirpath),
-			"%s/daemons/%s", rc_svcdir(), basename_c(service));
-
-	if (!(dp = opendir(dirpath)))
+	if (!(dp = do_opendirat(rc_dirfd(RC_DIR_DAEMONS), basename_c(service))))
 		return false;
 
 	while ((d = readdir(dp))) {
 		if (d->d_name[0] == '.')
 			continue;
 
-		snprintf(path, sizeof(dirpath) - (path - dirpath), "/%s",
-		    d->d_name);
-		fp = fopen(dirpath, "r");
-		if (!fp)
+		if (!(fp = do_fopenat(dirfd(dp), d->d_name, O_RDONLY)))
 			break;
 
 		while (xgetline(&line, &len, fp) != -1) {

--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -689,17 +689,6 @@ rc_deptree_update_needed(time_t *newest, char *file)
 	RC_STRING *s;
 	struct stat buf;
 	time_t mtime;
-	char *path;
-	const char *service_dir = rc_svcdir();
-
-	/* Create base directories if needed */
-	if (mkdir(service_dir, 0755) != 0 && errno != EEXIST)
-		fprintf(stderr, "mkdir '%s': %s\n", service_dir, strerror(errno));
-
-	for (size_t i = 1; i < RC_DIR_SYS_MAX; i++) {
-		if (mkdirat(rc_dirfd(RC_DIR_SVCDIR), dirnames[i], 0755) != 0 && errno != EEXIST)
-			fprintf(stderr, "mkdir `%s': %s\n", dirnames[i], strerror(errno));
-	}
 
 	/* Quick test to see if anything we use has changed and we have
 	 * data in our deptree. */

--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -636,6 +636,13 @@ rc_set_user(void)
 
 	rc_dirs.scriptdirs[SCRIPTDIR_USR] = rc_dirs.usrconfdir;
 	rc_dirs.scriptdirs[SCRIPTDIR_SVC] = rc_dirs.svcdir;
+
+	for (size_t i = 0; i < RC_DIR_MAX; i++) {
+		if (dirfds[i] == -1)
+			continue;
+		close(dirfds[i]);
+		dirfds[i] = -1;
+	}
 }
 
 const char * const *

--- a/src/librc/librc.h
+++ b/src/librc/librc.h
@@ -55,4 +55,21 @@
 #include "rc.h"
 #include "misc.h"
 
+static const char *const dirnames[RC_DIR_SYS_MAX] =
+{
+	[RC_DIR_STARTING] = "starting",
+	[RC_DIR_STARTED] = "started",
+	[RC_DIR_STOPPING] = "stopping",
+	[RC_DIR_INACTIVE] = "inactive",
+	[RC_DIR_WASINACTIVE] = "wasinactive",
+	[RC_DIR_FAILED] = "failed",
+	[RC_DIR_HOTPLUGGED] = "hotplugged",
+	[RC_DIR_DAEMONS] = "daemons",
+	[RC_DIR_OPTIONS] = "options",
+	[RC_DIR_EXCLUSIVE] = "exclusive",
+	[RC_DIR_SCHEDULED] = "scheduled",
+	[RC_DIR_INITD] = "init.d",
+	[RC_DIR_TMP] = "tmp",
+};
+
 #endif

--- a/src/librc/librc.h
+++ b/src/librc/librc.h
@@ -72,4 +72,6 @@ static const char *const dirnames[RC_DIR_SYS_MAX] =
 	[RC_DIR_TMP] = "tmp",
 };
 
+RC_STRINGLIST *config_list(int dirfd, const char *pathname);
+
 #endif

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -190,6 +190,34 @@ bool rc_runlevel_starting(void);
  * @return true if yes, otherwise false */
 bool rc_runlevel_stopping(void);
 
+enum rc_dir {
+	RC_DIR_SVCDIR,
+	RC_DIR_STARTING,
+	RC_DIR_STARTED,
+	RC_DIR_STOPPING,
+	RC_DIR_INACTIVE,
+	RC_DIR_WASINACTIVE,
+	RC_DIR_FAILED,
+	RC_DIR_HOTPLUGGED,
+	RC_DIR_DAEMONS,
+	RC_DIR_OPTIONS,
+	RC_DIR_EXCLUSIVE,
+	RC_DIR_SCHEDULED,
+	RC_DIR_INITD,
+	RC_DIR_TMP,
+	RC_DIR_SYS_MAX,
+	RC_DIR_SYSCONF = RC_DIR_SYS_MAX,
+	RC_DIR_USRCONF,
+	RC_DIR_RUNLEVEL,
+	RC_DIR_MAX,
+
+	RC_DIR_INVALID = -1
+};
+
+/*! @param runtime rc directory
+ * @return an open file descriptor, which should not be closed */
+int rc_dirfd(enum rc_dir);
+
 /*! @name RC
  * A service can be given as a full path or just its name.
  * If it's just a name then we try to resolve the service to a full path.

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -130,6 +130,12 @@ bool rc_is_user(void);
  * @return NULL terminated array of directory paths. */
 const char * const *rc_scriptdirs(void);
 
+/*! Get a list of fds for existing script directories
+ * containing a init.d and conf.d
+ * @param out pointer to store the list.
+ * @return number of fds in the list. */
+size_t rc_scriptdirfds(const int **fds);
+
 /*! The system configuration directory is where rc.conf
  * and other configuration files are stored.
  * @return Path to the system configuration directory */

--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -93,37 +93,26 @@ clean_failed(void)
 {
 	DIR *dp;
 	struct dirent *d;
-	char *path;
-	char *failed_dir;
-
-	xasprintf(&failed_dir, "%s/failed", rc_svcdir());
 
 	/* Clean the failed services state dir now */
-	if ((dp = opendir(failed_dir))) {
-		while ((d = readdir(dp))) {
-			if (d->d_name[0] == '.' &&
-			    (d->d_name[1] == '\0' ||
-				(d->d_name[1] == '.' && d->d_name[2] == '\0')))
-				continue;
+	if (!(dp = do_opendirat(rc_dirfd(RC_DIR_SVCDIR), "failed")))
+		return;
 
-			xasprintf(&path, "%s/%s", failed_dir, d->d_name);
-			if (unlink(path))
-				eerror("%s: unlink `%s': %s",
-				    applet, path, strerror(errno));
-			free(path);
-		}
-		closedir(dp);
+	while ((d = readdir(dp))) {
+		if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+			continue;
+
+		if (unlinkat(dirfd(dp), d->d_name, 0) == -1)
+			eerror("%s: unlink '%s/failed/%s': %s", applet, rc_svcdir(), d->d_name, strerror(errno));
 	}
-
-	free(failed_dir);
+	closedir(dp);
 }
 
 static void
 cleanup(void)
 {
+	int svcdirfd = rc_dirfd(RC_DIR_SVCDIR);
 	RC_PID *p, *tmp;
-	const char *svcdir = rc_svcdir();
-	static const char *subdirs[] = { "rc.starting", "rc.stopping" };
 
 	if (!rc_in_logger && !rc_in_plugin &&
 	    applet && (strcmp(applet, "rc") == 0 || strcmp(applet, "openrc") == 0))
@@ -139,12 +128,8 @@ cleanup(void)
 		}
 
 		/* Clean runlevel start, stop markers */
-		for (size_t i = 0; i < ARRAY_SIZE(subdirs); i++) {
-			char *path;
-			xasprintf(&path, "%s/%s", svcdir, subdirs[i]);
-			rmdir(path);
-			free(path);
-		}
+		unlinkat(svcdirfd, "rc.starting", AT_REMOVEDIR);
+		unlinkat(svcdirfd, "rc.stopping", AT_REMOVEDIR);
 
 		clean_failed();
 		rc_logger_close();
@@ -223,13 +208,9 @@ static void
 mark_interactive(void)
 {
 	FILE *fp;
-	char *dir;
 
-	xasprintf(&dir, "%s/interactive", rc_svcdir());
-	if ((fp = fopen(dir, "w")))
+	if ((fp = do_fopenat(rc_dirfd(RC_DIR_SVCDIR), "interactive", O_WRONLY | O_CREAT | O_TRUNC)))
 		fclose(fp);
-
-	free(dir);
 }
 
 static void
@@ -670,11 +651,9 @@ do_start_services(const RC_STRINGLIST *start_services, bool parallel)
 	bool interactive = false;
 	RC_SERVICE state;
 	bool crashed = false;
-	char *interactive_dir;
 
-	xasprintf(&interactive_dir, "%s/interactive", rc_svcdir());
 	if (!rc_yesno(getenv("EINFO_QUIET")))
-		interactive = exists(interactive_dir);
+		interactive = existsat(rc_dirfd(RC_DIR_SVCDIR), "interactive");
 	errno = 0;
 	crashed = rc_conf_yesno("rc_crashed_start");
 	if (errno == ENOENT)
@@ -733,9 +712,7 @@ do_start_services(const RC_STRINGLIST *start_services, bool parallel)
 			 strcmp(runlevel, getenv("RC_BOOTLEVEL")) == 0))
 		mark_interactive();
 	else
-		if (exists(interactive_dir))
-			unlink(interactive_dir);
-	free(interactive_dir);
+		unlinkat(rc_dirfd(RC_DIR_SVCDIR), "interactive", 0);
 }
 
 #ifdef RC_DEBUG
@@ -774,9 +751,6 @@ int main(int argc, char **argv)
 	RC_STRING *service;
 	bool going_down = false;
 	int depoptions = RC_DEP_STRICT | RC_DEP_TRACE;
-	const char *svcdir;
-	char *rc_starting, *rc_stopping;
-	char *deptree_skewed;
 	char *krunlevel = NULL;
 	const char *workingdir = "/";
 	char *pidstr = NULL;
@@ -864,8 +838,6 @@ int main(int argc, char **argv)
 	 * Also, add our configuration to it */
 	env_filter();
 	env_config();
-
-	svcdir = rc_svcdir();
 
 	newlevel = argv[optind++];
 	/* To make life easier, we only have the shutdown runlevel as
@@ -988,17 +960,14 @@ int main(int argc, char **argv)
 	if ((main_deptree = _rc_deptree_load(0, &regen)) == NULL)
 		eerrorx("failed to load deptree");
 
-	xasprintf(&deptree_skewed, "%s/clock-skewed", svcdir);
-	if (exists(deptree_skewed))
+	if (existsat(rc_dirfd(RC_DIR_SVCDIR), "clock-skewed"))
 		ewarn("WARNING: clock skew detected!");
-	free(deptree_skewed);
 
 	/* Clean the failed services state dir */
 	clean_failed();
 
-	xasprintf(&rc_stopping, "%s/rc.stopping", svcdir);
-	if (mkdir(rc_stopping, 0755) != 0)
-		eerrorx("%s: failed to create stopping dir '%s': %s", applet, rc_stopping, strerror(errno));
+	if (mkdirat(rc_dirfd(RC_DIR_SVCDIR), "rc.stopping", 0755) != 0)
+		eerrorx("%s: failed to create stopping dir '%s/rc.stopping': %s", applet, rc_svcdir(), strerror(errno));
 
 	/* Create a list of all services which we could stop (assuming
 	* they won't be active in the new or current runlevel) including
@@ -1079,8 +1048,7 @@ int main(int argc, char **argv)
 	    going_down ? newlevel : runlevel);
 	hook_out = 0;
 
-	rmdir(rc_stopping);
-	free(rc_stopping);
+	unlinkat(rc_dirfd(RC_DIR_SVCDIR), "rc.stopping", AT_REMOVEDIR);
 
 	/* Store the new runlevel */
 	if (newlevel) {
@@ -1097,9 +1065,7 @@ int main(int argc, char **argv)
 		rc_logger_close();
 #endif
 
-	xasprintf(&rc_starting, "%s/rc.starting", svcdir);
-	mkdir(rc_starting, 0755);
-	free(rc_starting);
+	mkdirat(rc_dirfd(RC_DIR_SVCDIR), "rc.starting", 0755);
 
 	rc_plugin_run(RC_HOOK_RUNLEVEL_START_IN, runlevel);
 	hook_out = RC_HOOK_RUNLEVEL_START_OUT;
@@ -1169,12 +1135,8 @@ int main(int argc, char **argv)
 	 * we need to delete them so that they are regenerated again in the
 	 * default runlevel as they may depend on things that are now
 	 * available */
-	if (regen && strcmp(runlevel, bootlevel) == 0) {
-		char *deptree_cache;
-		xasprintf(&deptree_cache, "%s/deptree", svcdir);
-		unlink(deptree_cache);
-		free(deptree_cache);
-	}
+	if (regen && strcmp(runlevel, bootlevel) == 0)
+		unlinkat(rc_dirfd(RC_DIR_SVCDIR), "deptree", 0);
 
 	return EXIT_SUCCESS;
 }

--- a/src/shared/misc.h
+++ b/src/shared/misc.h
@@ -47,23 +47,24 @@ pid_t exec_service(const char *, const char *);
 
 typedef struct rc_service_state_name {
 	RC_SERVICE state;
+	enum rc_dir dir;
 	const char *const name;
 } rc_service_state_name_t;
 
 /* We MUST list the states below 0x10 first
  * The rest can be in any order */
 static const rc_service_state_name_t rc_service_state_names[] = {
-	{ RC_SERVICE_STARTED,     "started" },
-	{ RC_SERVICE_STOPPED,     "stopped" },
-	{ RC_SERVICE_STARTING,    "starting" },
-	{ RC_SERVICE_STOPPING,    "stopping" },
-	{ RC_SERVICE_INACTIVE,    "inactive" },
-	{ RC_SERVICE_WASINACTIVE, "wasinactive" },
-	{ RC_SERVICE_HOTPLUGGED,  "hotplugged" },
-	{ RC_SERVICE_FAILED,      "failed" },
-	{ RC_SERVICE_SCHEDULED,   "scheduled"},
-	{ RC_SERVICE_CRASHED,     "crashed"},
-	{ 0, NULL}
+	{ RC_SERVICE_STARTED,     RC_DIR_STARTED,     "started" },
+	{ RC_SERVICE_STOPPED,     RC_DIR_INVALID,     "stopped" },
+	{ RC_SERVICE_STARTING,    RC_DIR_STARTING,    "starting" },
+	{ RC_SERVICE_STOPPING,    RC_DIR_STOPPING,    "stopping" },
+	{ RC_SERVICE_INACTIVE,    RC_DIR_INACTIVE,    "inactive" },
+	{ RC_SERVICE_WASINACTIVE, RC_DIR_WASINACTIVE, "wasinactive" },
+	{ RC_SERVICE_HOTPLUGGED,  RC_DIR_HOTPLUGGED,  "hotplugged" },
+	{ RC_SERVICE_FAILED,      RC_DIR_FAILED,      "failed" },
+	{ RC_SERVICE_SCHEDULED,   RC_DIR_SCHEDULED,   "scheduled"},
+	{ RC_SERVICE_CRASHED,     RC_DIR_INVALID,     "crashed"},
+	{ 0, -1, NULL}
 };
 
 /*


### PR DESCRIPTION
gives us atomic operations, removes almost all path string allocations, and reduces the number of syscalls