### PR TITLE
openrc-user: create by default and wait for boot runlevel at login

### DIFF
--- a/init.d/user.in
+++ b/init.d/user.in
@@ -15,6 +15,7 @@ user="${RC_SVCNAME#*.}"
 
 command="@RC_LIBEXECDIR@/bin/openrc-user"
 command_args="$user"
+ready="fd:3"
 
 start_pre() {
 	if [ "$user" = "$RC_SVCNAME" ]; then

--- a/sh/openrc-user.sh.in
+++ b/sh/openrc-user.sh.in
@@ -16,18 +16,19 @@ done
 mkdir -p "$svcdir"
 mkdir -p "$cachedir"
 
+for runlevel in boot "${rc_default_runlevel:-default}" shutdown; do
+	mkdir -p "$sysconf/runlevels/$runlevel"
+done
+
 case $1 in
 	start)
-		runlevel="${rc_default_runlevel:-default}"
 		cp -pr "$cachedir"/* "$_svcdir" 2>/dev/null
+		openrc --user boot || exit 1
+		exec openrc --user "${rc_default_runlevel:-default}"
 		;;
 	stop)
-		runlevel="shutdown"
 		cp -pr "$svcdir"/dep* "$svcdir/init.d" "$svcdir/conf.d" "$cachedir" 2>/dev/null
+		exec openrc --user shutdown
 		;;
 	*) eerror "no argument given to $0" && exit 1
 esac
-
-mkdir -p "$sysconf/runlevels/$runlevel"
-
-exec openrc --user "$_runlevel"

--- a/sh/openrc-user.sh.in
+++ b/sh/openrc-user.sh.in
@@ -2,32 +2,32 @@
 
 . @LIBEXECDIR@/sh/functions.sh
 
-_sysconf="${XDG_CONFIG_HOME:-${HOME}/.config}/rc"
-_cachedir="${XDG_CACHE_HOME:-${HOME}/.cache}/rc"
-_svcdir="${XDG_RUNTIME_DIR?}/openrc"
+sysconfdir="${XDG_CONFIG_HOME:-${HOME}/.config}/rc"
+cachedir="${XDG_CACHE_HOME:-${HOME}/.cache}/rc"
+svcdir="${XDG_RUNTIME_DIR?}/openrc"
 
-for config in "@SYSCONFDIR@/rc.conf" "$_sysconf/rc.conf"; do
+for config in "@SYSCONFDIR@/rc.conf" "$sysconfdir/rc.conf"; do
 	if [ -e "$config" ] && ! . "$config"; then
 		eerror "openrc-user: Failed loading $config"
 		exit 1
 	fi
 done
 
-mkdir -p "$_svcdir"
-mkdir -p "$_cachedir"
+mkdir -p "$svcdir"
+mkdir -p "$cachedir"
 
 case $1 in
 	start)
-		_runlevel="${rc_default_runlevel:-default}"
-		cp -pr "$_cachedir"/* "$_svcdir" 2>/dev/null
+		runlevel="${rc_default_runlevel:-default}"
+		cp -pr "$cachedir"/* "$_svcdir" 2>/dev/null
 		;;
 	stop)
-		_runlevel="shutdown"
-		cp -pr "$_svcdir"/dep* "$_svcdir/init.d" "$_svcdir/conf.d" "$_cachedir" 2>/dev/null
+		runlevel="shutdown"
+		cp -pr "$svcdir"/dep* "$svcdir/init.d" "$svcdir/conf.d" "$cachedir" 2>/dev/null
 		;;
 	*) eerror "no argument given to $0" && exit 1
 esac
 
-mkdir -p "$_sysconf/runlevels/$_runlevel"
+mkdir -p "$sysconf/runlevels/$runlevel"
 
 exec openrc --user "$_runlevel"

--- a/sh/openrc-user.sh.in
+++ b/sh/openrc-user.sh.in
@@ -24,6 +24,7 @@ case $1 in
 	start)
 		cp -pr "$cachedir"/* "$_svcdir" 2>/dev/null
 		openrc --user boot || exit 1
+		printf '\n' >&3
 		exec openrc --user "${rc_default_runlevel:-default}"
 		;;
 	stop)

--- a/src/openrc/rc.c
+++ b/src/openrc/rc.c
@@ -870,6 +870,9 @@ int main(int argc, char **argv)
 	 * nothing really needs to know that we're rebooting.
 	 * But for those that do, you can test against RC_REBOOT. */
 	if (newlevel) {
+		if (rc_is_user() && strcmp(newlevel, RC_LEVEL_SYSINIT) == 0)
+			eerrorx("%s: the sysinit runlevel can't be used for user services.", applet);
+
 		if (strcmp(newlevel, "reboot") == 0) {
 			newlevel = UNCONST(RC_LEVEL_SHUTDOWN);
 			setenv("RC_REBOOT", "YES", 1);


### PR DESCRIPTION
the boot runlevel systemwide has the special semantics of being automatically added to all other runlevels, while at the same time not having as much special interactions as the sysinit runlevel, so let's use it here to allow users to reliably set services to start *before* login completes, while the 'default' runlevel does proper parallelization with the login shell.

this increases the reliability of sessions, and avoids races such as `dbus-launch-if-needed` running before `init.d/dbus` has properly started, as well as allowing `rc-service --user ... status` to be ran in profile scripts to check for services in order to export vars.