### PR TITLE
*-daemon: filter all RC_ and SSD_ variables for the service

### DIFF
--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -1033,17 +1033,9 @@ int main(int argc, char **argv)
 #endif
 
 		TAILQ_FOREACH(env, env_list, entries) {
-			if ((strncmp(env->value, "RC_", 3) == 0 &&
-				strncmp(env->value, "RC_SERVICE=", 11) != 0 &&
-				strncmp(env->value, "RC_SVCNAME=", 11) != 0) ||
-				strncmp(env->value, "SSD_NICELEVEL=", 14) == 0 ||
-				strncmp(env->value, "SSD_IONICELEVEL=", 16) == 0 ||
-				strncmp(env->value, "SSD_OOM_SCORE_ADJ=", 18) == 0)
-			{
-				p = strchr(env->value, '=');
-				*p = '\0';
+			if (strncmp(env->value, "RC_", 3) == 0 && strncmp(env->value, "SSD_", 4) == 0) {
+				*strchr(env->value, '=') = '\0';
 				unsetenv(env->value);
-				continue;
 			}
 		}
 		rc_stringlist_free(env_list);

--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -511,17 +511,9 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 #endif
 
 	TAILQ_FOREACH(env, env_list, entries) {
-		if ((strncmp(env->value, "RC_", 3) == 0 &&
-			strncmp(env->value, "RC_SERVICE=", 11) != 0 &&
-			strncmp(env->value, "RC_SVCNAME=", 11) != 0) ||
-		    strncmp(env->value, "SSD_NICELEVEL=", 14) == 0 ||
-		    strncmp(env->value, "SSD_IONICELEVEL=", 16) == 0 ||
-		    strncmp(env->value, "SSD_OOM_SCORE_ADJ=", 18) == 0)
-		{
-			p = strchr(env->value, '=');
-			*p = '\0';
+		if (strncmp(env->value, "RC_", 3) == 0 && strncmp(env->value, "SSD_", 4) == 0) {
+			*strchr(env->value, '=') = '\0';
 			unsetenv(env->value);
-			continue;
 		}
 	}
 	rc_stringlist_free(env_list);


### PR DESCRIPTION
there's no real reason to leak those into the environment.

Closes: https://github.com/OpenRC/openrc/issues/808