### PR TITLE
wait for exclusive fds properly

### DIFF
--- a/src/openrc-run/meson.build
+++ b/src/openrc-run/meson.build
@@ -1,5 +1,5 @@
 executable('openrc-run',
-  ['openrc-run.c', misc_c, plugin_c, rc_exec_c, selinux_c, usage_c, version_h],
+  ['openrc-run.c', misc_c, timeutils_c, plugin_c, rc_exec_c, selinux_c, usage_c, version_h],
   c_args : [cc_audit_flags, cc_branding_flags, cc_pam_flags, cc_selinux_flags],
   link_with: [libeinfo, librc],
   dependencies: [audit_dep, dl_dep, pam_dep, pam_misc_dep, selinux_dep, util_dep, crypt_dep],

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -357,7 +357,7 @@ svc_exec(const char *arg1, const char *arg2)
 	int flags = 0;
 	struct pollfd fd[2];
 	int s;
-	char *buffer;
+	char buffer[BUFSIZ];
 	size_t bytes;
 	bool prefixed = false;
 	int slave_tty;
@@ -422,7 +422,6 @@ svc_exec(const char *arg1, const char *arg2)
 		/* UNREACHABLE */
 	}
 
-	buffer = xmalloc(sizeof(char) * BUFSIZ);
 	fd[0].fd = signal_pipe[0];
 	fd[1].fd = master_tty;
 	fd[0].events = fd[1].events = POLLIN;
@@ -478,8 +477,6 @@ svc_exec(const char *arg1, const char *arg2)
 				warn_timeout = wait_timeout;
 		}
 	}
-
-	free(buffer);
 
 	sigemptyset (&sigchldmask);
 	sigaddset (&sigchldmask, SIGCHLD);

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -424,13 +424,9 @@ svc_exec(const char *arg1, const char *arg2)
 
 	buffer = xmalloc(sizeof(char) * BUFSIZ);
 	fd[0].fd = signal_pipe[0];
+	fd[1].fd = master_tty;
 	fd[0].events = fd[1].events = POLLIN;
 	fd[0].revents = fd[1].revents = 0;
-	if (master_tty >= 0) {
-		fd[1].fd = master_tty;
-		fd[1].events = POLLIN;
-		fd[1].revents = 0;
-	}
 
 	for (;;) {
 		int timeout;

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -93,7 +93,8 @@ static RC_STRINGLIST *use_services;
 static RC_STRINGLIST *want_services;
 static RC_HOOK hook_out;
 static int exclusive_fd = -1, master_tty = -1;
-static bool sighup, skip_mark, in_background, deps, dry_run;
+static bool in_background, deps, dry_run;
+static volatile bool sighup, skip_mark;
 static pid_t service_pid;
 static int signal_pipe[2] = { -1, -1 };
 

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -367,7 +367,7 @@ exec_service(const char *service, const char *arg)
 		fprintf(stderr, "fork: %s\n",strerror (errno));
 		svc_unlock(basename_c(service), fd);
 	} else
-		fcntl(fd, F_SETFD, fcntl(fd, F_GETFD, 0) | FD_CLOEXEC);
+		close(fd);
 
 	sigprocmask(SIG_SETMASK, &old, NULL);
 	free(file);

--- a/src/shared/misc.h
+++ b/src/shared/misc.h
@@ -73,8 +73,8 @@ static const rc_service_state_name_t rc_service_state_names[] = {
  */
 int is_writable(const char *);
 
-#define service_start(service) exec_service(service, "start");
-#define service_stop(service)  exec_service(service, "stop");
+#define service_start(service) exec_service(service, "start")
+#define service_stop(service)  exec_service(service, "stop")
 
 int parse_mode(mode_t *, char *);
 


### PR DESCRIPTION
* misc: fix the exclusive lockfile fd remaining open in the caller of `exec_service`
* openrc-run: properly wait for the exclusive flock in svc_wait and svc_exec
* openrc: don't solve start dependencies, instead have services start their own dependencies, it simplifies the overall mechanism, aligns the code path of `openrc` with the codepath of `rc-service`, and i think that allows for better parallelism (not sure, need to test some more)