### PR TITLE
*-daemon: fix order of chroot

### DIFF
--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <limits.h>
+#include <inttypes.h>
 #include <grp.h>
 #include <pthread.h>
 #include <pwd.h>
@@ -854,9 +855,9 @@ int main(int argc, char **argv)
 		printf("\n");
 		eindent();
 		if (uid != 0)
-			einfo("as user id %d", uid);
+			einfo("as user id %"PRIuMAX, (uintmax_t)uid);
 		if (gid != 0)
-			einfo("as group id %d", gid);
+			einfo("as group id %"PRIuMAX, (uintmax_t)gid);
 		if (ch_root)
 			einfo("in root `%s'", ch_root);
 		if (ch_dir)
@@ -964,18 +965,18 @@ int main(int argc, char **argv)
 #endif
 
 		if (gid && setgid(gid))
-			eerrorx("%s: unable to set groupid to %d",
-			    applet, gid);
+			eerrorx("%s: unable to set groupid to %"PRIuMAX,
+			    applet, (uintmax_t)gid);
 		if (changeuser && initgroups(changeuser, gid))
-			eerrorx("%s: initgroups (%s, %d)",
-			    applet, changeuser, gid);
+			eerrorx("%s: initgroups (%s, %"PRIuMAX")",
+			    applet, changeuser, (uintmax_t)gid);
 #ifdef __linux__
 		if (uid && cap_setuid(uid))
 #else
 		if (uid && setuid(uid))
 #endif
-			eerrorx ("%s: unable to set userid to %d",
-			    applet, uid);
+			eerrorx ("%s: unable to set userid to %"PRIuMAX,
+			    applet, (uintmax_t)uid);
 
 		/* Close any fd's to the passwd database */
 		endpwent();

--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -47,6 +47,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <inttypes.h>
 #include <sys/wait.h>
 #ifdef __linux__
 # include <sys/syscall.h> /* For io priority */
@@ -889,6 +890,8 @@ int main(int argc, char **argv)
 
 	/* Child process - lets go! */
 	if (pid == 0) {
+		gid_t group_buf[32], *group_list = group_buf;
+		int group_count = ARRAY_SIZE(group_buf);
 		pid_t mypid = getpid();
 		close(pipefd[0]); /* Close the read end of the pipe. */
 		umask(numask);
@@ -932,6 +935,29 @@ int main(int argc, char **argv)
 			fclose(fp);
 		}
 
+#ifdef HAVE_PAM
+		if (changeuser != NULL) {
+			pamr = pam_start("start-stop-daemon",
+			    changeuser, &conv, &pamh);
+
+			if (pamr == PAM_SUCCESS)
+				pamr = pam_acct_mgmt(pamh, PAM_SILENT);
+			if (pamr == PAM_SUCCESS)
+				pamr = pam_open_session(pamh, PAM_SILENT);
+			if (pamr != PAM_SUCCESS)
+				eerrorx("%s: pam error: %s",
+					applet, pam_strerror(pamh, pamr));
+		}
+#endif
+		if (changeuser && getgrouplist(changeuser, gid, group_list, &group_count) < 0) {
+			group_list = xmalloc(group_count * sizeof(*group_list));
+			if (getgrouplist(changeuser, gid, group_list, &group_count) < 0)
+				eerrorx("%s: getgrouplist(%s, %"PRIuMAX")", applet, changeuser, (uintmax_t)gid);
+		}
+
+		/* Close any fd's to the passwd database */
+		endpwent();
+
 		if (ch_root && chroot(ch_root) < 0)
 			eerrorx("%s: chroot `%s': %s",
 			    applet, ch_root, strerror(errno));
@@ -949,27 +975,14 @@ int main(int argc, char **argv)
 			fclose(fp);
 		}
 
-#ifdef HAVE_PAM
-		if (changeuser != NULL) {
-			pamr = pam_start("start-stop-daemon",
-			    changeuser, &conv, &pamh);
-
-			if (pamr == PAM_SUCCESS)
-				pamr = pam_acct_mgmt(pamh, PAM_SILENT);
-			if (pamr == PAM_SUCCESS)
-				pamr = pam_open_session(pamh, PAM_SILENT);
-			if (pamr != PAM_SUCCESS)
-				eerrorx("%s: pam error: %s",
-					applet, pam_strerror(pamh, pamr));
-		}
-#endif
 
 		if (gid && setgid(gid))
 			eerrorx("%s: unable to set groupid to %"PRIuMAX,
 			    applet, (uintmax_t)gid);
-		if (changeuser && initgroups(changeuser, gid))
-			eerrorx("%s: initgroups (%s, %"PRIuMAX")",
-			    applet, changeuser, (uintmax_t)gid);
+		if (changeuser && setgroups(group_count, group_list))
+			eerrorx("%s: setgroups() failed", applet);
+		if (group_list != group_buf)
+			free(group_list);
 #ifdef __linux__
 		if (uid && cap_setuid(uid))
 #else
@@ -977,9 +990,6 @@ int main(int argc, char **argv)
 #endif
 			eerrorx ("%s: unable to set userid to %"PRIuMAX,
 			    applet, (uintmax_t)uid);
-
-		/* Close any fd's to the passwd database */
-		endpwent();
 
 #ifdef __linux__
 		if (cap_iab != NULL) {

--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -449,15 +449,15 @@ RC_NORETURN static void child_process(char *exec, char **argv)
 #endif
 
 	if (gid && setgid(gid))
-		eerrorx("%s: unable to set groupid to %d", applet, gid);
+		eerrorx("%s: unable to set groupid to %"PRIuMAX, applet, (uintmax_t)gid);
 	if (changeuser && initgroups(changeuser, gid))
-		eerrorx("%s: initgroups (%s, %d)", applet, changeuser, gid);
+		eerrorx("%s: initgroups (%s, %"PRIuMAX")", applet, changeuser, (uintmax_t)gid);
 #ifdef __linux__
 	if (uid && cap_setuid(uid))
 #else
 	if (uid && setuid(uid))
 #endif
-		eerrorx ("%s: unable to set userid to %d", applet, uid);
+		eerrorx ("%s: unable to set userid to %"PRIuMAX, applet, (uintmax_t)uid);
 
 	/* Close any fd's to the passwd database */
 	endpwent();


### PR DESCRIPTION
in the current order, we use pam_start and read /etc/group *after* chroot-ing. this is undocumented in the manpages, causes issues (#543) and is also very inconsistent (e.g we get the gid from the root database, not the chroot one. also stuff like expand_home() happens before chroot etc).

so make pam_start and getgrouplist happen before chroot().

Ref: https://github.com/OpenRC/openrc/pull/517
Fixes: https://github.com/OpenRC/openrc/issues/543