### PR TITLE
unblock signal handlers during signal_setup

### DIFF
--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -365,7 +365,7 @@ svc_exec(const char *arg1, const char *arg2)
 	sigset_t oldmask;
 	int64_t wait_timeout, warn_timeout, now;
 	RC_STRINGLIST *keywords;
-	bool forever;
+	bool forever = false;
 
 	keywords = rc_deptree_depend(deptree, applet, "keyword");
 	if (rc_stringlist_find(keywords, "-timeout") ||

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -270,18 +270,6 @@ signal_setup(int sig, void (*handler)(int))
 }
 
 int
-signal_setup_restart(int sig, void (*handler)(int))
-{
-	struct sigaction sa;
-
-	memset(&sa, 0, sizeof (sa));
-	sigemptyset(&sa.sa_mask);
-	sa.sa_handler = handler;
-	sa.sa_flags = SA_RESTART;
-	return sigaction(sig, &sa, NULL);
-}
-
-int
 svc_lock(const char *applet, bool ignore_lock_failure)
 {
 	int fd = openat(rc_dirfd(RC_DIR_EXCLUSIVE), applet, O_WRONLY | O_CREAT | O_NONBLOCK, 0664);

--- a/src/shared/misc.c
+++ b/src/shared/misc.c
@@ -340,8 +340,11 @@ exec_service(const char *service, const char *arg)
 		sigaction(SIGUSR1, &sa, NULL);
 		sigaction(SIGWINCH, &sa, NULL);
 
-		/* Unmask signals */
-		sigprocmask(SIG_SETMASK, &old, NULL);
+		/* Unmask all signals.
+		 * We might've been called from pam_openrc by
+		 * a process that masked signals we rely on.
+		 * Bug: https://bugs.gentoo.org/953748 */
+		sigprocmask(SIG_UNBLOCK, &full, NULL);
 
 		/* Safe to run now */
 		execl(file, file, "--lockfd", sfd, arg, (char *) NULL);

--- a/src/shared/misc.h
+++ b/src/shared/misc.h
@@ -40,7 +40,6 @@ bool rc_conf_yesno(const char *var);
 void env_filter(void);
 void env_config(void);
 int signal_setup(int sig, void (*handler)(int));
-int signal_setup_restart(int sig, void (*handler)(int));
 int svc_lock(const char *, bool);
 int svc_unlock(const char *, int);
 pid_t exec_service(const char *, const char *);


### PR DESCRIPTION
openrc-run can be called from places that don't reset the signal mask
before exec, example being the pam close_session session hook called
from runuser, which leads to svc_exec hanging, as SIGCHLD is never
delivered.

Bug: https://bugs.gentoo.org/953748