### PR TITLE
conf.d/install agetty conf files via meson

### DIFF
--- a/conf.d/meson.build
+++ b/conf.d/meson.build
@@ -60,3 +60,11 @@ elif os == 'NetBSD'
 endif
 
 install_data(conf_data, install_dir : conf_d_dir)
+
+if get_option('sysvinit') == true and os == 'Linux'
+  foreach x : get_option('agetty')
+    getty_name = 'agetty.' + x
+    install_data('agetty', install_dir: conf_d_dir,
+      rename: getty_name)
+  endforeach
+endif


### PR DESCRIPTION
Since e56171b2a1815560e03b9e9b2ef507a02c59e288, the agetty symlinks are installed via meson option. There's no reason to not do the same for the conf.d files as well.