### PR TITLE
checkpath: don't check dirfd value in get_dirfd loop condition

### DIFF
--- a/src/checkpath/checkpath.c
+++ b/src/checkpath/checkpath.c
@@ -105,7 +105,7 @@ static int get_dirfd(char *path, bool symlinks)
 	if (!symlinks)
 		flags |= O_NOFOLLOW;
 	flags |= O_RDONLY;
-	while (dirfd > 0 && item && components > 1) {
+	while (item && components > 1) {
 		str = xstrdup(linkpath ? linkpath : item);
 		new_dirfd = openat(dirfd, str, flags);
 		if (new_dirfd == -1)


### PR DESCRIPTION
This check was probably meant to check for `dirfd >= 0` since `0` would also be a valid value for dirfd, otherwise we would make assumption about how file descriptors are assigned to us. If dirfd is -1 then we error out if before we reach the loop or in the loop body. Therefore, unless I am misunderstanding the purpose of this check entirely, we can leave it out.

This was discovered while upgrading the Alpine Linux OpenRC package to 0.62. Starting with this version, when using `checkpath` in `start_pre()` the zero FD is opened with `CLOEXEC` by the parent process (`openrc-run`), and hence closed when executing `checkpath`:

	[pid 28605] execve("/usr/libexec/rc/bin/checkpath", ["checkpath", "--pipe", "/run/user-1000/ustatus.fifo"], 0x7f0d15afbda8 /* 32 vars */) = 0
	[pid 28605] open("/etc/ld-musl-x86_64.path", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = -1 ENOENT (No such file or directory)
	[pid 28605] open("/lib/libeinfo.so.1", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = -1 ENOENT (No such file or directory)
	[pid 28605] open("/usr/local/lib/libeinfo.so.1", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = -1 ENOENT (No such file or directory)
	[pid 28605] open("/usr/lib/libeinfo.so.1", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = 0
	[pid 28605] close(0)                    = 0
	[pid 28605] open("/lib/librc.so.1", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = -1 ENOENT (No such file or directory)
	[pid 28605] open("/usr/local/lib/librc.so.1", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = -1 ENOENT (No such file or directory)
	[pid 28605] open("/usr/lib/librc.so.1", O_RDONLY|O_LARGEFILE|O_CLOEXEC) = 0
	[pid 28605] close(0)                    = 0

Therefore, `dirfd` is assigned the zero FD since it is the first opened file in `checkpath`:

	openat(AT_FDCWD, "/", O_RDONLY|O_LARGEFILE) = 0

and the loop body, modified in this patch is never executed; thereby, causing checkpath to attempt to open the file to be created in `/`, which naturally fails.

I haven't investigated why, starting with OpenRC 0.62, the parent process opens stdin with CLOEXEC and if this is something that should be fixed instead.