### PR TITLE
librc: dirfd is initalized with zero not with -1

### DIFF
--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -638,8 +638,11 @@ rc_set_user(void)
 	rc_dirs.scriptdirs[SCRIPTDIR_SVC] = rc_dirs.svcdir;
 
 	for (size_t i = 0; i < RC_DIR_MAX; i++) {
-		if (dirfds[i] == -1)
+		/* dirfd is zero-initialized, though zero is a valid
+		 * FD, dirfd should never contain FDs which are <= 2. */
+		if (dirfds[i] <= 0)
 			continue;
+
 		close(dirfds[i]);
 		dirfds[i] = -1;
 	}


### PR DESCRIPTION
Without this patch, this code therefore closes FD 0 repeatedly.

See https://github.com/OpenRC/openrc/pull/851

This fixes a regression from 27eae2c380239e7baf113c1b228c6fe679e6a541.