### PR TITLE
build: fix installation of getty symlinks

### DIFF
--- a/init.d/meson.build
+++ b/init.d/meson.build
@@ -105,11 +105,10 @@ install_symlink('functions.sh',
   install_dir: init_d_dir)
 
 if get_option('sysvinit') == true and os == 'Linux'
-  default_runlevel_dir = get_option('sysconfdir') / 'runlevels' / 'default'
   foreach x : get_option('agetty')
     link_name = 'agetty.' + x
-    install_symlink(link_name, install_dir: init_d_dir, pointing_to: 'agetty')
-    install_symlink(link_name, install_dir: default_runlevel_dir,
-      pointing_to: init_d_dir / link_name)
+    install_symlink(link_name,
+      install_dir: init_d_dir,
+      pointing_to: 'agetty')
   endforeach
 endif

--- a/runlevels/meson.build
+++ b/runlevels/meson.build
@@ -89,4 +89,11 @@ foreach runlevel: runlevels.keys()
       install_dir: runlevel_dir / runlevel,
       pointing_to: init_d_dir / service) 
   endforeach
+  if get_option('sysvinit') == true and os == 'Linux' and runlevel == 'default'
+    foreach tty : get_option('agetty')
+      install_symlink('agetty.' + tty,
+        install_dir: runlevel_dir / runlevel,
+        pointing_to: init_d_dir / 'agetty.' + tty)
+    endforeach
+  endif
 endforeach


### PR DESCRIPTION
The getty symlinks are installed both in the init.d directory and the default runlevel directory. This makes the getty installation consistent with the rest of the runlevel setup.