### PR TITLE
start-stop-daemon: add longopts_help value for --notify

### DIFF
--- a/src/start-stop-daemon/start-stop-daemon.c
+++ b/src/start-stop-daemon/start-stop-daemon.c
@@ -171,6 +171,7 @@ const char * const longopts_help[] = {
 	"Print dots each second while waiting",
 	"Set process scheduler",
 	"Set process scheduler priority",
+	"Configures experimental notification behaviour",
 	longopts_help_COMMON
 };
 const char *usagestring = NULL;


### PR DESCRIPTION
Without this, the help output from `--notify` onwards is incorrectly off-by-one, e.g.:

```
      --notify <arg>                Display this help output
  -h, --help                        Disable color output
  -C, --nocolor                     Display software version
```

By aligning its length with that of `longopts`, this also fixes a segfault we've observed in our arm64 builds.