### PR TITLE
build: define init_d_dir

### DIFF
--- a/runlevels/meson.build
+++ b/runlevels/meson.build
@@ -1,4 +1,5 @@
-runlevel_dir =get_option('sysconfdir') / 'runlevels'
+runlevel_dir = get_option('sysconfdir') / 'runlevels'
+init_d_dir = get_option('sysconfdir') / 'init.d'
 
 sysinit = []
 sysinit_linux = [


### PR DESCRIPTION
otherwise muon errors due to it being undefined. (haven't tested with meson).