### PR TITLE
supervisor=s6: rework support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,6 +54,7 @@ Kaarle Ritvanen <kaarle.ritvanen@datakunkku.fi>
 Kfir Lavi <lavi.kfir@gmail.com>
 Kirill Elagin <kirelagin@gmail.com>
 Lars Wendler <polynomial-c@gentoo.org>
+Laurent Bercot <ska-devel@skarnet.org>
 Lorand Kelemen <lorand.kelemen@indgroup.eu>
 Marc Joliet <marcec@gmx.de>
 Marien Zwart <marienz@gentoo.org>

--- a/init.d/s6-svscan.in
+++ b/init.d/s6-svscan.in
@@ -18,38 +18,37 @@ command_args="$RC_SVCDIR"
 command_background=yes
 pidfile=/var/run/s6-svscan.pid
 umask=022
-# notify=fd:4  # when notify=fd is fixed, uncomment here and in svscanboot
+# notify=fd:4  # when notify=fd is fixed, uncomment here and add -d4 in svscanboot
 
 depend() {
-        need localmount
+	need localmount
 }
 
 _stop_and_crop() {
-        if s6-svok "$1" 2>/dev/null ; then
-                s6-svc -dwDkx "$1"
-        fi
-        rm -rf "$1/supervise" "$1/event"
+	if s6-svok "$1" 2>/dev/null ; then
+		s6-svc -dwD -kx -- "$1"
+	fi
+	rm -rf -- "$1/supervise" "$1/event"
 }
 
-stop() {
-        local scandir="$RC_SVCDIR/s6-scan" servicedirs="$RC_SVCDIR/s6-services"
-        default_stop
+stop_post() {
+	local scandir="$RC_SVCDIR/s6-scan" servicedirs="$RC_SVCDIR/s6-services"
+	rm -rf -- "$scandir"
 	if test -d "$servicedirs" ; then
-	        ebegin "Cleaning stray supervised processes"
-	        rm -rf "$scandir"
-	        for i in `ls -1 "$servicedirs"` ; do
-	                _stop_and_crop "$servicedirs/$i" &
-	                if test -d "$servicedirs/$i/log" ; then
-	                        _stop_and_crop "$servicedirs/$i/log" &
-	                fi
-	        done
-	        wait
-	        eend 0
-	        if test -d "$RC_CACHEDIR" ; then
-	                ebegin "Storing service directories in cache"
-	                rm -rf "$RC_CACHEDIR/s6-services"
-	                cp -pPR "$servicedirs" "$RC_CACHEDIR/"
-	                eend $?
-	        fi
+		ebegin "Cleaning stray supervised processes"
+		for i in `ls -1 "$servicedirs"` ; do
+			_stop_and_crop "$servicedirs/$i" &
+			if test -d "$servicedirs/$i/log" ; then
+				_stop_and_crop "$servicedirs/$i/log" &
+			fi
+		done
+		wait
+		eend 0
+		if test -d "$RC_CACHEDIR" ; then
+			ebegin "Storing service directories in cache"
+			rm -rf -- "$RC_CACHEDIR/s6-services"
+			cp -pPR -- "$servicedirs" "$RC_CACHEDIR/"
+			eend $?
+		fi
 	fi
 }

--- a/init.d/s6-svscan.in
+++ b/init.d/s6-svscan.in
@@ -1,5 +1,5 @@
 #!@SBINDIR@/openrc-run
-# Copyright 2025 The OpenRC Authors.
+# Copyright (c) 2025 The OpenRC Authors.
 # See the Authors file at the top-level directory of this distribution and
 # https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
 #

--- a/init.d/s6-svscan.in
+++ b/init.d/s6-svscan.in
@@ -1,5 +1,5 @@
 #!@SBINDIR@/openrc-run
-# Copyright (c) 2015 The OpenRC Authors.
+# Copyright 2025 The OpenRC Authors.
 # See the Authors file at the top-level directory of this distribution and
 # https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
 #
@@ -9,34 +9,47 @@
 # This file may not be copied, modified, propagated, or distributed
 # except according to the terms contained in the LICENSE file.
 
-command=/bin/s6-svscan
-command_args="${RC_SVCDIR}"/s6-scan
+# We currently start the s6 supervision tree as an
+# openrc service. It's using ssd for now; we may
+# switch to supervise-daemon later.
+
+command="${RC_LIBEXECDIR}/sh/s6-svscanboot.sh"
+command_args="$RC_SVCDIR"
 command_background=yes
 pidfile=/var/run/s6-svscan.pid
+umask=022
+# notify=fd:4  # when notify=fd is fixed, uncomment here and in svscanboot
 
-depend()
-{
-	need localmount
+depend() {
+        need localmount
 }
 
-start_pre()
-{
-	if [ ! -e "$command" ]; then
-		eerror "$command is missing (please install s6)"
-	else
-		einfo "Creating s6 scan directory"
-		checkpath -d -m 0755 "$RC_SVCDIR"/s6-scan
+_stop_and_crop() {
+        if s6-svok "$1" 2>/dev/null ; then
+                s6-svc -dwDkx "$1"
+        fi
+        rm -rf "$1/supervise" "$1/event"
+}
+
+stop() {
+        local scandir="$RC_SVCDIR/s6-scan" servicedirs="$RC_SVCDIR/s6-services"
+        default_stop
+	if test -d "$servicedirs" ; then
+	        ebegin "Cleaning stray supervised processes"
+	        rm -rf "$scandir"
+	        for i in `ls -1 "$servicedirs"` ; do
+	                _stop_and_crop "$servicedirs/$i" &
+	                if test -d "$servicedirs/$i/log" ; then
+	                        _stop_and_crop "$servicedirs/$i/log" &
+	                fi
+	        done
+	        wait
+	        eend 0
+	        if test -d "$RC_CACHEDIR" ; then
+	                ebegin "Storing service directories in cache"
+	                rm -rf "$RC_CACHEDIR/s6-services"
+	                cp -pPR "$servicedirs" "$RC_CACHEDIR/"
+	                eend $?
+	        fi
 	fi
-	return
-}
-
-stop_post()
-{
-	ebegin "Stopping any remaining s6 services"
-	s6-svc -dx "${RC_SVCDIR}"/s6-scan/* 2>/dev/null || true
-	eend $?
-
-	ebegin "Stopping any remaining s6 service loggers"
-	s6-svc -dx "${RC_SVCDIR}"/s6-scan/*/log 2>/dev/null || true
-	eend $?
 }

--- a/s6-guide.md
+++ b/s6-guide.md
@@ -1,9 +1,9 @@
-Using S6 with OpenRC
+Using s6 with OpenRC
 ====================
 
 Beginning with OpenRC-0.16, we support using the s6 supervision suite
-from Skarnet Software in place of start-stop-daemon for monitoring
-daemons [1].
+from skarnet.org in place of start-stop-daemon for monitoring daemons [1].
+
 
 ## Setup
 
@@ -19,10 +19,14 @@ functions.
 ### Dependencies
 
 All OpenRC service scripts that want their daemons monitored by s6
-should have the following line added to their dependencies to make sure
+may have the following line added to their dependencies to make sure
 the s6 scan directory is being monitored.
 
 need s6-svscan
+
+Starting with 0.63, it is not necessary to manually add this dependency.
+OpenRC should deduce it automatically if your service file includes the
+supervisor=s6 line. (See right below.)
 
 ### Variable Settings
 
@@ -31,23 +35,117 @@ your service script, you should set this variable as follows:
 
 supervisor=s6
 
-Several other variables affect s6 services. They are documented on the
-openrc-run man page, but I will list them here for convenience:
+Several other variables affect s6 services. Some of them are generic,
+whether you're using start-stop-daemon, supervise-daemon or s6:
 
-s6_service_path - the path to the s6 service directory. The default is
-/var/svc.d/$RC_SVCNAME.
+command, command_args, command_args_foreground: these variables  will be
+run as a shell command line. Do not start with "exec", the s6 backend
+will add it automatically.
 
-s6_svwait_options_start - the options to pass to s6-svwait when starting
-the service. If this is not set, s6-svwait will not be called.
+Some variables are used with supervisor=s6 the same way as with
+supervisor=supervise-daemon:
 
-s6_force_kill - Should we try to force kill this service if the
-s6_service_timeout_stop timeout expires when shutting down this service?
-The default is yes.
+output_logger, error_logger (mutually exclusive, you can only have
+one logger; error_logger will log _both_ stdout and stderr, unless
+you also define an output_log which will log your stdout separately
+to a file.)
 
-s6_service_timeout_stop - the amount of time, in milliseconds, s6-svc
-should wait for a service to go down when stopping.
+input_file, output_log, error_log (a corresponding _logger program
+overrides a _log file)
 
-This is very early support, so feel free to file bugs if you have
-issues.
+directory, chroot, umask, command_user (command_user must be a username
+appearing in your user database, not a numerical uid)
 
-[1] http://www.skarnet.org/software/s6
+notify (only the fd:X method is supported: when ready, your daemon must
+write a (possibly empty) line to file descriptor X)
+
+stopsig (accepts signal names and numbers)
+
+Some variables are specific to the supervisor=s6 backend:
+
+error_logger=auto, s6_log_arguments: if you set your error_logger
+(or your output_logger, but error_logger is recommended) to "auto",
+then a logger service is automatically built using the s6-log
+program, logging to the /var/log/$RC_SVCNAME directory with TAI64N
+timestamps, automatic rotations every 1 MiB of data, and a maximum
+of 10 archived files. You can fine-tune the settings given to s6-log
+via the s6_log_arguments variable (but not the logging directory;
+for more control you can still set error_logger manually, even to
+an s6-log command line!)
+
+timeout_ready=N: wait for up to N milliseconds for the service to
+become up, and fail otherwise. If notify=fd:X has been set, it waits
+for the service to be _ready_ instead, which is what you really want.
+If N=0, OpenRC will wait indefinitely until the service is up/ready.
+If this variable is not set, it will not wait at all and report
+success as soon as the command to bring the service up has
+successfully been sent.
+
+timeout_down=N: wait for up to N milliseconds when stopping the service,
+until s6 reports it as down. If it fails, the service might still be
+successfully brought down. If N=0, OpenRC will wait indefinitely for
+the service to die (this works well in conjunction with timeout_kill,
+see below); if the variable is unset, it will not wait at all.
+
+timeout_kill=N: when openrc tries to stop the service, s6 sends a SIGTERM
+(or the value of stopsig). If that signal has not managed to bring the
+service down after N milliseconds, a SIGKILL will be sent. This is
+useful when you want to make sure your service is down; use in
+conjunction with timeout_down. N=0 makes no sense here. Not setting
+timeout_kill means no SIGKILL will be sent.
+
+
+## How it works internally, starting with 0.63
+
+The first time start() is called, OpenRC uses all the variables in the
+service file to build a service directory for s6: a run script, possibly
+a notification-fd file, etc. This service directory is then linked into
+the scan directory and s6-svscan is told to register it and spawn a
+s6-supervise process on it.
+
+This means that all the information needed for your service should be
+given, declaratively, in your service file (and your configuration file
+if you have one). You do not need to build your service directory
+yourself anymore, this is done automatically: in true OpenRC fashion,
+the service file is the One True Source of information for running
+your service.
+
+The run script for the s6 service directory is built with in the
+execline language, because execline makes script generation easier
+than sh. However, the daemon execution itself is still done via
+  sh -c "$command $command_args $command_args_foreground"
+for compatibility with other backends. In other words: you can forget
+that execline is even there, all the user-facing parts use sh as their
+interpreter and it's all you need to worry about.
+
+When the service is stopped, the service directory is unlinked from the
+scan directory, but the service directory itself remains. If the service
+is started again, the same service directory is linked again: it does
+not need to be rebuilt, unless the service file (typically in /etc/init.d)
+or the configuration file (typically in /etc/conf.d) have changed since,
+in which case it is created anew.
+
+On shutdown, the existing service directories (minus their runtime data)
+are stored into the OpenRC cache, and restored at the next boot.
+
+### Logging
+
+If you don't set a logger at all, the stdout and stderr of your service
+will fall through to the catch-all logger of the s6-svscan service, which
+logs all s6 services that don't have a dedicated logger. These logs are
+accessible in /run/openrc/s6-logs (or whatever $RC_SVCDIR/s6-logs is on
+your machine).
+
+
+## Future direction
+
+The s6 backend in OpenRC aims to be as close as possible to the
+supervise-daemon backend, and most services should be able to use one
+or the other interchangeably. More service file variables may be supported
+in the future as supervise-daemon evolves; they will be documented in this
+file. There is a also possibility that the preferred interface for defining
+a service command line changes in a future version of OpenRC; in that case,
+the change will apply to both supervise-daemon and s6 equally.
+
+
+[1] https://skarnet.org/software/s6/

--- a/sh/gendepends.sh.in
+++ b/sh/gendepends.sh.in
@@ -120,6 +120,9 @@ do
 
 		if . "$_dir/$RC_SVCNAME"; then
 			echo "$RC_SVCNAME" >&3
+			if [ -n "$supervisor" ] && [ "$supervisor" = s6 ]; then
+				need s6-svscan
+			fi
 			_depend
 		fi
 		)

--- a/sh/meson.build
+++ b/sh/meson.build
@@ -23,7 +23,8 @@ sh_config = [
 scripts_config = [
   'gendepends.sh.in',
   'openrc-run.sh.in',
-  'openrc-user.sh.in'
+  'openrc-user.sh.in',
+  's6-svscanboot.sh.in'
   ]
 
 if os == 'Linux'

--- a/sh/s6-svscanboot.sh.in
+++ b/sh/s6-svscanboot.sh.in
@@ -1,0 +1,23 @@
+#!@SHELL@ -e
+
+scandir="$1/s6-scan"
+logdir="$1/s6-logs"
+execlineb=`command -v execlineb`
+
+mkdir -p "$logdir"
+mkdir -p -m 02755 "$scandir/s6-svscan-log"
+echo 3 > "$scandir/s6-svscan-log/notification-fd"
+mkfifo -m 0600 "$scandir/s6-svscan-log/fifo" 2>/dev/null || :
+cat > "$scandir/s6-svscan-log/run" <<EOF
+#!$execlineb -S1
+fdmove -c 1 2
+redirfd -rnb 0 fifo
+exec -c
+s6-log -bpd3 -- t s1048576 n10 "$logdir"
+EOF
+chmod 0755 "$scandir/s6-svscan-log/run"
+
+# when notify=fd is fixed, add -d4 after -X3
+exec redirfd -wnb 1 "$scandir/s6-svscan-log/fifo" \
+fdmove -c 2 1 \
+s6-svscan -X3 -- "$scandir" 0</dev/null 3>/dev/console

--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -1,6 +1,6 @@
 # Start / stop / status functions for s6 support
 
-# Copyright (c) 2015 The OpenRC Authors.
+# Copyright (c) 2015-2025 The OpenRC Authors.
 # See the Authors file at the top-level directory of this distribution and
 # https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
 #
@@ -10,67 +10,216 @@
 # This file may not be copied, modified, propagated, or distributed
 #    except according to the terms contained in the LICENSE file.
 
-[ -z "${s6_service_path}" ] && s6_service_path="/var/svc.d/${RC_SVCNAME}"
+# Variables that the supervisor=s6 backend understands:
+# command, command_args, command_args_foreground (command will be interpreted by sh)
+# output_logger, error_logger, output_log, error_log (the former two are mutually exclusive)
+# input_file, directory, chroot, umask, command_user
+# notify (only fd), stopsig
+#
+# Extra variables:
+# Timeouts: all in milliseconds, 0 for infinity, undefined for no waiting
+# timeout_ready: wait for the service to become up, or ready if notify=fd:X
+# timeout_down: wait for the service to stop
+# timeout_kill: if not stopped after that amount, send a SIGKILL
 
-_s6_force_kill() {
-	local pid
-	s6_service_link="${RC_SVCDIR}/s6-scan/${s6_service_path##*/}"
-	pid="${3%)}"
-	[ -z "${pid}" ] && return 0
-	if kill -0 "${pid}" 2> /dev/null; then
-		ewarn "Sending DOWN & KILL for ${RC_SVCNAME}"
-		s6-svc -dk "${s6_service_link}"
-		sleep 1
-		kill -0 "${pid}" 2>/dev/null && return 1
+extra_commands="restart reload ${extra_commands}"
+
+# Call this on every entry point, for readability
+_s6_set_variables() {
+	name="${name:-${RC_SVCNAME}}"
+	_execlineb="$(command -v execlineb)"
+	_scandir="${RC_SVCDIR}/s6-scan"
+	_servicedirs="${RC_SVCDIR}/s6-services"
+	_service="$_scandir/$name"
+}
+
+_s6_available() {
+	s6-svscanctl "$_scandir" 2>/dev/null
+}
+
+_execline_available() {
+	test -n "$_execlineb" && "$_execlineb" -Pc true 2>/dev/null
+}
+
+_s6_sanity_checks() {
+	if ! _s6_available ; then
+		eerror "No supervision tree running on $_scandir"
+		return 1
+	fi
+	if ! _execline_available ; then
+		eerror "No execlineb interpreter accessible"
+		return 1
+	fi
+	if test -n "$notify" && test "${notify##fd:}" = "$notify" ; then
+		ewarn "Only the notify=fd method is supported - notify setting will be ignored"
+		notify=
+	fi
+	if test -n "$output_logger" && test -n "$error_logger" ; then
+		ewarn "error_logger will be used in priority over output_logger"
+		output_logger=
+	fi
+	if test -n "$output_logger" && test -n "$output_log" ; then
+		ewarn "output_logger will be used in priority over output_log"
+		output_log=
+	fi
+	if test -n "$error_logger" && test -n "$error_log" ; then
+		ewarn "error_logger will be used in priority over error_log"
+		error_log=
+	fi
+	if test "${output_logger}${error_logger}" = auto ; then
+		s6_log_arguments="${s6_log_arguments:-t s1048576 n10}"
+	elif test -n "$s6_log_arguments" ; then
+		ewarn "s6_log_arguments ignored because the logger was not 'auto'"
+		s6_log_arguments=
 	fi
 	return 0
 }
 
+_s6_force_stop() {
+	s6-svunlink "$_scandir" "$name"
+}
+
+_s6_servicedir_creation_needed() {
+	local dir="$_servicedirs/$name" conffile="{$RC_SERVICE%/*}/../conf.d/${RC_SERVICE##*/}"
+	if ! test -e "$dir" ; then
+		return 0
+	fi
+	if ! test -d "$dir" ; then
+		rm -f "$dir"
+		return 0
+	fi
+	if test "$RC_SERVICE" -nt "$dir" || test -f "$conffile" -a "$conffile" -nt "$dir" ; then
+		_s6_force_stop
+		rm -rf "$dir"
+		return 0
+	fi
+	return 1
+}
+
+_s6_servicedir_create() {
+	local logger="${output_logger}${error_logger}" dir="$_servicedirs/$name"
+
+	mkdir -p -m 0700 "$dir"
+	if test -n "$notify" && test "${notify##fd:}" != "$notify" ; then
+		echo "${notify##fd:}" > "$dir/notification-fd"
+	fi
+	if test -n "$timeout_kill" ; then
+		echo "$timeout_kill" > "$dir/timeout-kill"
+	fi
+	if test -n "$stopsig" ; then
+		echo "$stopsig" > "$dir/down-signal"
+	fi
+
+	{
+		# We use execline here because it makes code generation easier.
+		# The command will still be interpreted by sh in the end.
+		echo "#!$_execlineb -S1"
+		if test -n "$umask" ; then
+			echo "umask \"$umask\""
+		fi
+		if test -n "$error_logger" ; then
+			echo 'fdmove -c 2 1'
+		elif test -n "$error_log" ; then
+			echo "redirfd -w 2 \"$error_log\""
+		fi
+		if test -n "$output_log" ; then
+			echo "redirfd -w 1 \"$output_log\""
+		fi
+		if test -n "$input_file" ; then
+			echo "redirfd -r 0 \"$input_file\""
+		fi
+		if test -n "$chroot" ; then
+			echo "cd \"$chroot\" chroot ."
+		fi
+		if test -n "$directory" ; then
+			echo "cd \"$directory\""
+		fi
+		if test -n "$command_user" ; then
+			echo "s6-setuidgid \"$command_user\""
+		fi
+		echo "sh -c \"exec $command $command_args $command_args_foreground\""
+	} > "$dir/run"
+	chmod 0755 "$dir/run"
+
+	if test -n "$logger" ; then  # TODO: get an unprivileged uid to run the logger as
+		mkdir -m 0755 "$dir/log"
+		mkdir -p -m 02755 "/var/log/$name"
+		if test "$logger" = auto ; then
+			echo 3 > "$dir/log/notification-fd"
+			{
+				echo "#!$_execlineb -S1"
+				echo "s6-log -d3 -- ${s6_log_arguments} /var/log/$name"
+			} > "$dir/log/run"
+		else
+			{
+				echo '#!/bin/sh -e'
+				echo "exec $logger"
+			} > "$dir/log/run"
+		fi
+		chmod 0755 "$dir/log/run"
+	fi
+	chmod 0755 "$dir"
+}
+
 s6_start()
 {
-	if [ ! -d "${s6_service_path}" ]; then
-		eerror "${s6_service_path} does not exist."
- 	return 1
- fi
-	s6_service_link="${RC_SVCDIR}/s6-scan/${s6_service_path##*/}"
-	ebegin "Starting ${name:-$RC_SVCNAME}"
-	ln -sf "${s6_service_path}" "${s6_service_link}"
-	s6-svscanctl -na "${RC_SVCDIR}"/s6-scan
-	sleep 1.5
-	s6-svc -u "${s6_service_link}"
-	if [ -n "$s6_svwait_options_start" ]; then
-		s6-svwait ${s6_svwait_options_start} "${s6_service_link}"
+	local r waitcommand waitname
+	_s6_set_variables
+	if ! _s6_sanity_checks ; then
+		eerror "s6 sanity checks failed, cannot start service"
+ 		return 1
 	fi
-	sleep 1.5
-	set -- $(s6-svstat "${s6_service_link}")
-	[ "$1" = "up" ]
-	eend $? "Failed to start ${name:-$RC_SVCNAME}"
+	if _s6_servicedir_creation_needed ; then
+		ebegin "Starting $name"
+		_s6_servicedir_create
+	else
+		ebegin "Starting $name (using cached service directory)"
+	fi
+	if s6-svlink "$_scandir" "$_servicedirs/$name" ; then : ; else
+		r=$?
+		eend $r "Failed to s6-svlink $name into $_scandir"
+		return $r
+	fi
+	if test -n "$timeout_ready" ; then
+		if test -n "$notify" ; then
+			waitcommand='-U'
+			waitname=ready
+		else
+			waitcommand='-u'
+			waitname=up
+		fi
+		if s6-svwait $waitcommand -t "$timeout_ready" -- "$_service" ; then : ; else
+			r=$?
+			s6-svc -d -- "$_service"
+			eend $r "Failed to become $waitname in $timeout_ready milliseconds"
+			return $r
+		fi
+	fi
+	eend 0
 }
 
-s6_stop()
-{
-	if [ ! -d "${s6_service_path}" ]; then
-		eerror "${s6_service_path} does not exist."
- 	return 1
- fi
-	s6_service_link="${RC_SVCDIR}/s6-scan/${s6_service_path##*/}"
-	ebegin "Stopping ${name:-$RC_SVCNAME}"
-	s6-svc -d -wD -T ${s6_service_timeout_stop:-60000} "${s6_service_link}"
-	set -- $(s6-svstat "${s6_service_link}")
-	[ "$1" = "up" ] &&
-		yesno "${s6_force_kill:-yes}" &&
-			_s6_force_kill "$@"
-	set -- $(s6-svstat "${s6_service_link}")
-	[ "$1" = "down" ]
-	eend $? "Failed to stop ${name:-$RC_SVCNAME}"
+s6_stop() {
+	_s6_set_variables
+	ebegin "Stopping $name"
+	s6-svunlink ${timeout_down:+-t} $timeout_down -- "$_scandir" "$name"
+	eend $? "Failed to stop $name"
 }
 
-s6_status()
-{
-	s6_service_link="${RC_SVCDIR}/s6-scan/${s6_service_path##*/}"
-	if [ -L "${s6_service_link}" ]; then
-		s6-svstat "${s6_service_link}"
+s6_status() {
+	_s6_set_variables
+	if s6-svok "$_service" 2>/dev/null ; then
+		s6-svstat -- "$_service"
 	else
 		_status
 	fi
+}
+
+restart() {
+	_s6_set_variables
+	s6-svc -r -- "$_service"
+}
+
+reload() {
+	_s6_set_variables
+	s6-svc -h -- "$_service"
 }

--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -34,11 +34,11 @@ _s6_set_variables() {
 }
 
 _s6_available() {
-	s6-svscanctl "$_scandir" 2>/dev/null
+	s6-svscanctl -- "$_scandir" 2>/dev/null
 }
 
 _execline_available() {
-	test -n "$_execlineb" && "$_execlineb" -Pc true 2>/dev/null
+	test -n "$_execlineb" && "$_execlineb" -Pc 'exit 0' 2>/dev/null
 }
 
 _s6_sanity_checks() {
@@ -90,7 +90,7 @@ _s6_servicedir_creation_needed() {
 	fi
 	if test "$RC_SERVICE" -nt "$dir" || test -f "$conffile" -a "$conffile" -nt "$dir" ; then
 		_s6_force_stop
-		rm -rf "$dir"
+		rm -rf -- "$dir"
 		return 0
 	fi
 	return 1
@@ -99,7 +99,7 @@ _s6_servicedir_creation_needed() {
 _s6_servicedir_create() {
 	local logger="${output_logger}${error_logger}" dir="$_servicedirs/$name"
 
-	mkdir -p -m 0700 "$dir"
+	mkdir -p -m 0700 -- "$dir"
 	if test -n "$notify" && test "${notify##fd:}" != "$notify" ; then
 		echo "${notify##fd:}" > "$dir/notification-fd"
 	fi
@@ -120,13 +120,13 @@ _s6_servicedir_create() {
 		if test -n "$error_logger" ; then
 			echo 'fdmove -c 2 1'
 		elif test -n "$error_log" ; then
-			echo "redirfd -w 2 \"$error_log\""
+			echo "redirfd -w 2 -- \"$error_log\""
 		fi
 		if test -n "$output_log" ; then
-			echo "redirfd -w 1 \"$output_log\""
+			echo "redirfd -w 1 -- \"$output_log\""
 		fi
 		if test -n "$input_file" ; then
-			echo "redirfd -r 0 \"$input_file\""
+			echo "redirfd -r 0 -- \"$input_file\""
 		fi
 		if test -n "$chroot" ; then
 			echo "cd \"$chroot\" chroot ."
@@ -175,7 +175,7 @@ s6_start()
 	else
 		ebegin "Starting $name (using cached service directory)"
 	fi
-	if s6-svlink "$_scandir" "$_servicedirs/$name" ; then : ; else
+	if s6-svlink -- "$_scandir" "$_servicedirs/$name" ; then : ; else
 		r=$?
 		eend $r "Failed to s6-svlink $name into $_scandir"
 		return $r

--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -76,7 +76,7 @@ _s6_sanity_checks() {
 }
 
 _s6_force_stop() {
-	s6-svunlink "$_scandir" "$name"
+	s6-svunlink -- "$_scandir" "$name"
 }
 
 _s6_servicedir_creation_needed() {
@@ -85,7 +85,7 @@ _s6_servicedir_creation_needed() {
 		return 0
 	fi
 	if ! test -d "$dir" ; then
-		rm -f "$dir"
+		rm -f -- "$dir"
 		return 0
 	fi
 	if test "$RC_SERVICE" -nt "$dir" || test -f "$conffile" -a "$conffile" -nt "$dir" ; then


### PR DESCRIPTION
 This commit modernizes the support for the supervisor=s6
backend. It reworks how the supervision tree is started and how the services are defined.

 The s6-svscan service now runs its own catch-all logger,
logging to $RC_SVCDIR/s6-logs.

 A service defining supervisor=s6 now has an automatic "need"
dependency to s6-svscan. A service directory will be automatically built from the information in the service file, under the $RC_SVCDIR/s6-services repository. These service directories are cached until the service file (or config) changes. So, services don't need to provide their service directories themselves anymore; they still can, but they'll need to do the s6-sv[un]link thing themselves.

 The documentation has been updated.

 Anna, please add yourself to the AUTHORS file, because it is
ridiculous that I am now in it and you are not.