### PR TITLE
Fixes for eindent: out-of-bounds array access, proper alignment

### DIFF
--- a/man/einfo.3
+++ b/man/einfo.3
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" Copyright (c) 2007-2025 The OpenRC Authors.
 .\" See the Authors file at the top-level directory of this distribution and
 .\" https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
 .\"
@@ -143,7 +143,7 @@ at the column
 .Fa col .
 .Pp
 .Fn eindent
-indents subsequent calls to the above functions by 3 characters.
+indents subsequent calls to the above functions by 2 characters.
 .Fn eoutdent
 removes an
 .Fn eindent .

--- a/sh/functions.sh.in
+++ b/sh/functions.sh.in
@@ -1,7 +1,7 @@
 # Allow any sh script to work with einfo functions and friends
 # We also provide a few helpful functions for other programs to use
 
-# Copyright (c) 2007-2015 The OpenRC Authors.
+# Copyright (c) 2007-2025 The OpenRC Authors.
 # See the Authors file at the top-level directory of this distribution and
 # https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
 #
@@ -16,7 +16,6 @@ RC_GOT_FUNCTIONS="yes"
 eindent()
 {
 	: $(( EINFO_INDENT = ${EINFO_INDENT:-0} + 2 ))
-	[ "$EINFO_INDENT" -gt 40 ] && EINFO_INDENT=40
 	export EINFO_INDENT
 }
 

--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -459,7 +459,6 @@ _eindent(FILE * EINFO_RESTRICT stream)
 {
 	char *env = getenv("EINFO_INDENT");
 	int amount = 0;
-	char indent[INDENT_MAX];
 
 	if (env) {
 		errno = 0;
@@ -468,14 +467,9 @@ _eindent(FILE * EINFO_RESTRICT stream)
 			amount = 0;
 		else if (amount > INDENT_MAX)
 			amount = INDENT_MAX;
-
-		if (amount > 0)
-			memset(indent, ' ', (size_t)amount);
 	}
 
-	/* Terminate it */
-	memset(indent + amount, 0, 1);
-	return fprintf(stream, "%s", indent);
+	return fprintf(stream, "%*s", amount, "");
 }
 
 static const char *

--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -4,7 +4,7 @@
 */
 
 /*
- * Copyright (c) 2007-2024 The OpenRC Authors.
+ * Copyright (c) 2007-2025 The OpenRC Authors.
  * See the Authors file at the top-level directory of this distribution and
  * https://github.com/OpenRC/openrc/blob/HEAD/AUTHORS
  *
@@ -793,8 +793,6 @@ eindent(void)
 			amount = 0;
 	}
 	amount += INDENT_WIDTH;
-	if (amount > INDENT_MAX)
-		amount = INDENT_MAX;
 	xasprintf(&num, "%08d", amount);
 	setenv("EINFO_INDENT", num, 1);
 	free(num);


### PR DESCRIPTION
This fixes issues #868 and #869, plus a trivial fix for the `einfo` man page.
