### PR TITLE
Add missing description for --notify option of supervise-daemon

### DIFF
--- a/src/supervise-daemon/supervise-daemon.c
+++ b/src/supervise-daemon/supervise-daemon.c
@@ -152,6 +152,7 @@ const char * const longopts_help[] = {
 	"Redirect stdout to process",
 	"Redirect stderr to process",
 	"reexec (used internally)",
+	"Configures experimental notification behaviour",
 	longopts_help_COMMON
 };
 const char *usagestring = NULL;


### PR DESCRIPTION
This diff fixes incorrect output of --help due to missing help string. Because longots_help arrays was shorter by one element, running --help produced incorrect result. It could also lead to crash due to OOB access.

Before:
$ RC_SVCNAME=foo supervise-daemon foo --help | tail -n 9
      --stderr-logger <arg>         Redirect stderr to process
  -3, --reexec                      reexec (used internally)
      --notify <arg>                Display this help output
  -h, --help                        Disable color output
  -C, --nocolor                     Display software version
  -V, --version                     Run verbosely
  -v, --verbose                     Run quietly (repeat to suppress errors)
  -q, --quiet                       Run in user mode
  -U, --user                        healthcheck-timer

After:
 -3, --reexec                      reexec (used internally)
      --notify <arg>                Open notify pipe
  -h, --help                        Display this help output
  -C, --nocolor                     Disable color output
  -V, --version                     Display software version
  -v, --verbose                     Run verbosely
  -q, --quiet                       Run quietly (repeat to suppress errors)
  -U, --user                        Run in user mode