### PR TITLE
librc: don't create /run/openrc itself on demand.

### DIFF
--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -693,6 +693,8 @@ rc_deptree_update_needed(time_t *newest, char *file)
 
 	/* Quick test to see if anything we use has changed and we have
 	 * data in our deptree. */
+	if (mkdir(rc_svcdir(), 0755) != 0 && errno != EEXIST)
+		fprintf(stderr, "mkdir '%s': %s\n", rc_svcdir(), strerror(errno));
 
 	if (fstatat(rc_dirfd(RC_DIR_SVCDIR), "deptree", &buf, 0) == 0) {
 		mtime = buf.st_mtime;


### PR DESCRIPTION
this is a temporary fix, in a system that boots with / as rw, /run unmounted, and has rc_parallel on, openrc would create a dirfd to /run/openrc before mounting /run, thus keeping an open fd to the old /run mountpoint, and creating 'exclusive' lockfiles under it, that subsequent services can't see nor lock on.

Fixes: https://github.com/OpenRC/openrc/issues/859
Fixes: 07d6f4d5