### PR TITLE
Clarify that cgroups v2 is the default mount mode for cgroup

### DIFF
--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -199,8 +199,8 @@ rc_tty_number=12
 # "hybrid" mounts cgroups version 2 on /sys/fs/cgroup/unified and
 # cgroups version 1 on /sys/fs/cgroup.
 # "legacy" mounts cgroups version 1 on /sys/fs/cgroup
-# "unified" mounts cgroups version 2 on /sys/fs/cgroup
-#rc_cgroup_mode="unified"
+# "unified" mounts cgroups version 2 on /sys/fs/cgroup (this is the default).
+#rc_cgroup_mode="hybrid"
 
 # This is a list of controllers which should be enabled for cgroups version 2
 # when hybrid mode is being used.


### PR DESCRIPTION
Change rc_cgroup_mode="unified" to "hybrid" as unified is reduntant