### PR TITLE
AUTHORS: add navi

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Andrew Gregory <andrew.gregory.8@gmail.com>
 Anthony Donnelly <Amzo@archbsd.com>
 Anthony G. Basile <basile@opensource.dyc.edu>
 Anthony G. Basile <blueness@gentoo.org>
+Anna (navi) Figueiredo Gomes <navi@vlhl.dev>
 Austin S. Hemmelgarn <ahferroin7@gmail.com>
 Benda Xu <heroxbd@gentoo.org>
 Björn Baumbach <bb@sernet.de>


### PR DESCRIPTION
navi is one of the co-maintainers of OpenRC, can cut releases by herself since 4ea8adf13aae30101a0d810225faf9389f8b5c6f, and wrote user services support.

Do as ska suggests in 2a2e6be1b700c05938833c92d9cc5070b3e34f3f and bless her with AUTHORS.