### PR TITLE
openrc-run: block SIGCHLD during fork() to avoid race with reaping

### DIFF
--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -351,7 +351,7 @@ openrc_sh_exec(const char *openrc_sh, const char *arg1, const char *arg2)
 static int
 svc_exec(const char *arg1, const char *arg2)
 {
-	int ret, fdout = fileno(stdout);
+	int ret, fdout = fileno(stdout), tmp;
 	struct termios tt;
 	struct winsize ws;
 	int flags = 0;
@@ -488,8 +488,11 @@ svc_exec(const char *arg1, const char *arg2)
 	sigprocmask (SIG_BLOCK, &sigchldmask, &oldmask);
 
 	close(signal_pipe[0]);
-	close(signal_pipe[1]);
+	/* We should set signal_pipe[1] to -1 before closing it to avoid invalid write if
+	 * sighandler runs between close() and cleaning the variable */
+	tmp = signal_pipe[1];
 	signal_pipe[0] = signal_pipe[1] = -1;
+	close(tmp);
 
 	sigprocmask (SIG_SETMASK, &oldmask, NULL);
 


### PR DESCRIPTION
The signal handler in openrc-run expects service_pid to be set when the child
process exists, but there is no guarantee that the execution thread will have
been scheduled before the signal handler, leading to service not being detected
as started properly very occasionally.

This can be tested with the following reproducer:
```
#include <signal.h>
#include <stdio.h>
#include <string.h>
#include <sys/wait.h>
#include <unistd.h>

static pid_t service_pid;

static void
handle_signal(int sig)
{
	int status;
	pid_t pid;

	switch (sig) {
	case SIGCHLD:
		while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
			if (pid != service_pid)
				printf("Got %d != %d\n", pid, service_pid);
		}
		break;
	default:
		printf("caught unknown signal %d\n", sig);
	}
}

int
signal_setup(int sig, void (*handler)(int))
{
        struct sigaction sa;

        memset(&sa, 0, sizeof (sa));
        sigemptyset(&sa.sa_mask);
        sa.sa_handler = handler;
        return sigaction(sig, &sa, NULL);
}

int main(int argc, char **argv)
{
	signal_setup(SIGCHLD, handle_signal);

	while (1) {
#ifdef FIX
		sigset_t full, old;
		sigfillset(&full);
		sigprocmask(SIG_SETMASK, &full, &old);
#endif
		service_pid = fork();
#ifdef FIX
		sigprocmask(SIG_SETMASK, &old, NULL);
#endif

		if (service_pid < 0) {
			printf("fork fail %m\n");
			return 1;
		}
		// exit child immediately
		if (service_pid == 0)
			return 0;
		// wait for child process to stop a different way
		while (kill(service_pid, 0) >= 0);
	}

	return 0;
}
```

Fixes #895