### PR TITLE
librc-depend: clear dirfds unconditionally

### DIFF
--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -693,10 +693,10 @@ rc_deptree_update_needed(time_t *newest, char *file)
 
 	/* Quick test to see if anything we use has changed and we have
 	 * data in our deptree. */
-	if (mkdir(rc_svcdir(), 0755) == 0)
-		clear_dirfds(); /* clear our cached dirfds if we created a new svcdir, as a sanity check */
-	else if (errno != EEXIST)
+	if (mkdir(rc_svcdir(), 0755) != 0 && errno != EEXIST)
 		fprintf(stderr, "mkdir '%s': %s\n", rc_svcdir(), strerror(errno));
+
+	clear_dirfds(); /* clear our cached dirfds as a sanity check */
 
 	if (fstatat(rc_dirfd(RC_DIR_SVCDIR), "deptree", &buf, 0) == 0) {
 		mtime = buf.st_mtime;


### PR DESCRIPTION
init.sh creates the directory, which means we never actually do it here early at boot

Fixes: 9c3f974
Fixes: https://github.com/OpenRC/openrc/pull/893