### PR TITLE
init.d/net-online: Minor bug fix and minor feature addition

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -50,6 +50,7 @@ start ()
 		[ "$carrier" = 1 ] && : $((carriers += 1))
 		read operstate 2> /dev/null < /sys/class/net/$dev/operstate ||
 			operstate=
+		[ -e /sys/class/net/$dev/tun_flags ] && operstate=up
 		[ "$operstate" = up ] && : $((configured += 1))
 	done
 	[ $configured -eq $ifcount ] && [ $carriers -ge 1 ] && break


### PR DESCRIPTION
The code that reads interface status from the sysfs had stderr redirection in the wrong order, which means that, in the event that the interface does not yet exist, the read will display an error message that was meant to be suppressed.

Also added a single line that allows tun/tap interfaces to be properly handled. It turns out that /sys/class/net/${interface}/operstate shows "unknown" for tun/tap interfaces, not "up", which is the value that net-online depends on. So tun/tap interfaces need minor special handling.