### PR TITLE
silence out pam_openrc on login, and add rc_autostart_users to rc.conf

### DIFF
--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -15,6 +15,11 @@
 # set to YES.
 #rc_interactive="YES"
 
+# Set to "NO" if you don't want pam_openrc autostarting user services. This
+# effectively disables the pam module, without the need of removing it from
+# the pam configuration files.
+#rc_autostart_user="YES"
+
 # If we need to drop to a shell, you can specify it here.
 # If not specified we use $SHELL, otherwise the one specified in /etc/passwd,
 # otherwise /bin/sh

--- a/src/pam_openrc/pam_openrc.c
+++ b/src/pam_openrc/pam_openrc.c
@@ -23,6 +23,10 @@ exec_openrc(pam_handle_t *pamh, bool opening)
 	struct passwd *user;
 	pid_t pid = -1;
 
+	errno = 0;
+	if (!rc_yesno(rc_conf_value("rc_autostart_user")) && errno == 0)
+		return PAM_SUCCESS;
+
 	setenv("EINFO_LOG", "pam_openrc", true);
 
 	if (pam_get_item(pamh, PAM_SERVICE, (const void **)&session) != PAM_SUCCESS) {


### PR DESCRIPTION
we should also mark the service as stopped instead of failed -- at least while we're still in this experimental step