### PR TITLE
NEWS.md, user-guide.md: no longer experimental

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ the information in this file is in reverse order.
 
 ## OpenRC 0.62
 
+User services are no longer considered experimental.
+
 supervise-daemon and start-stop-daemon now support -1/--stdin as means
 of piping a file or fifo to the standard input of the daemon.
 

--- a/user-guide.md
+++ b/user-guide.md
@@ -177,7 +177,7 @@ This allows to print colour-coded status notices and other things.
 To make the output consistent the bundled service scripts all use ebegin/eend to 
 print nice messages.
 
-# User services -- Experimental
+# User services
 
 OpenRC supports managing services for users.
 


### PR DESCRIPTION
We don't consider these experimental anymore as of 0.62 as bugs have been ironed out, they've been in Gentoo ~arch for several months, and in an Alpine release for several months also.