### PR TITLE
Check for minimum padding required in rc-update

### DIFF
--- a/src/rc-update/rc-update.c
+++ b/src/rc-update/rc-update.c
@@ -191,7 +191,9 @@ show(RC_STRINGLIST *runlevels, bool verbose)
 		}
 
 		if (inone || verbose) {
-			printf(" %20s |", service->value);
+			/* For more information on why padding is 26, see issue 937: */
+			/* https://github.com/OpenRC/openrc/issues/937 */
+			printf(" %26s |", service->value);
 			TAILQ_FOREACH(runlevel, in, entries)
 			    printf (" %s", runlevel->value);
 			printf("\n");


### PR DESCRIPTION
Before printing the service's names one by one, check the minimum padding that is going to be required for the longest service name.

Bug: https://github.com/OpenRC/openrc/issues/937