### PR TITLE
init.d/net-online: pass -n to ping to avoid rDNS overhead

### DIFF
--- a/init.d/net-online.in
+++ b/init.d/net-online.in
@@ -66,7 +66,7 @@ start ()
  	ping_test_host="${ping_test_host:-google.com}"
  	if [ -n "$ping_test_host" ]; then
 		while $infinite || [ $timeout -gt 0 ]; do
-			ping -c 1 $ping_test_host > /dev/null 2>&1
+			ping -n -c 1 $ping_test_host > /dev/null 2>&1
 			rc=$?
 			[ $rc -eq 0 ] && break
 			sleep 1


### PR DESCRIPTION
e21b01b97e84f81589f52e087d2b2ac53f0bf144 fixed one of the issues mentioned in Gentoo bug #650584 but not the other one. `ping` without `-n` will perform reverse DNS lookups for IPs which we don't want, as it introduces a delay and confuses the calculation we make.

Bug: https://bugs.gentoo.org/650584
Bug: https://github.com/OpenRC/openrc/issues/353