### PR TITLE
 Remove restart(); add framework for reload() support

### DIFF
--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -203,6 +203,17 @@ default_status()
 	$func
 }
 
+default_reload()
+{
+	case "$supervisor" in
+		s6) s6_reload ;;
+		?*)
+			eerror "$RC_SVCNAME: undefined function 'reload'"
+			exit 1
+			;;
+	esac
+}
+
 # Template start / stop / status functions
 # package init scripts may override these, but the bodies are as minimal as
 # possible, so that the init scripts can creatively wrap default_*
@@ -220,6 +231,11 @@ stop()
 status()
 {
 	default_status
+}
+
+reload()
+{
+	default_reload
 }
 
 # Start debug output

--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -115,7 +115,7 @@ _s6_servicedir_create() {
 	fi
 
 	{
-		# We use execline here because it makes code generation easier.
+		# Generating execline code here because it is much easier than generating sh.
 		# The command will still be interpreted by sh in the end.
 		echo "#!$_execlineb -S1"
 		if test -n "$umask" ; then
@@ -222,12 +222,9 @@ s6_status() {
 	fi
 }
 
-restart() {
+s6_reload() {
 	_s6_set_variables
-	s6-svc -r -- "$_service"
-}
-
-reload() {
-	_s6_set_variables
+	ebegin "Reloading $name"
 	s6-svc -h -- "$_service"
+	eend $? "s6-svc -h command failed"
 }


### PR DESCRIPTION
 OpenRC will never call restart(), so scrap the definition in
openrc-run.sh and s6.sh.
 reload() caused a weird error message when used without
supervisor=s6, so add proper support for generic reload(), instantiated for s6, and with a better default error message for other backends - which can now add support for reload() down the line.

 Also clarify a comment, and add info messages on s6_reload.