### PR TITLE
man/openrc-shutdown.8: correct kexec option

### DIFF
--- a/man/openrc-shutdown.8
+++ b/man/openrc-shutdown.8
@@ -29,7 +29,7 @@ time
 .Nm
 .Op Fl d , -no-write
 .Op Fl D , -dry-run
-.Op Fl k , -kexec
+.Op Fl K , -kexec
 time
 .Nm
 .Op Fl d , -no-write
@@ -62,7 +62,7 @@ Print the action that would be taken without executing it. This is to
 allow testing.
 .It Fl H , -halt
 Stop all services, kill all remaining processes and halt the system.
-.It Fl k , -kexec
+.It Fl K , -kexec
 Stop all services, kill all processes and boot directly into a new
 kernel loaded via
 .Xr kexec 8 .


### PR DESCRIPTION
7689106a changed the kexec option for openrc-shutdown from "-k" to "-K" but the manpage was never updated.