### PR TITLE
rc-service: print name of command on exec failure

### DIFF
--- a/src/rc-service/rc-service.c
+++ b/src/rc-service/rc-service.c
@@ -168,6 +168,6 @@ int main(int argc, char **argv)
 		return 0;
 	*argv = service;
 	execv(*argv, argv);
-	eerrorx("%s: %s", applet, strerror(errno));
+	eerrorx("%s: Failed executing '%s': %s", applet, *argv, strerror(errno));
 	/* NOTREACHED */
 }


### PR DESCRIPTION
For example with noexec in the home, it changes:

    $ rc-service -U foo start
     * rc-service: Permission denied

to:

    $ rc-service -U foo start
     * rc-service: Failed executing '/home/haelwenn/.config/rc/init.d/foo': Permission denied
