### PR TITLE
Added dmcrypt to localmount

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -13,7 +13,7 @@ description="Mounts disks and swap according to /etc/fstab."
 
 depend()
 {
-	need fsck root
+	need fsck root dmcrypt
 	use lvm modules
 	after clock lvm modules
 	keyword -docker -podman -jail -lxc -prefix -systemd-nspawn -vserver -wsl


### PR DESCRIPTION
I noticed when installing Artix Linux with only home folder encryption (setup via `/etc/conf.d/dmcrypt`) the passphrase is correctly asked at boot for the encrypted home folder and decrypted if correct passphrase is given but the drive does not get mounted to `/home`. It was not a `/etc/fstab` issue because after logging in as root `mount -a` did mount the drive to `/home` correctly.

The fix was to add `dmcrypt` to `/etc/conf.d/localmount` under  `depend()` after `need fsck root`. Would it be useful if this was added to `localmount` or is there a better way of doing it? 