### PR TITLE
openrc-run.8: Add "Default stop/start" section and table.

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -8,7 +8,7 @@
 .\" This file may not be copied, modified, propagated, or distributed
 .\"    except according to the terms contained in the LICENSE file.
 .\"
-.Dd November 30, 2017
+.Dd February 14, 2026
 .Dt openrc-run 8 SMM
 .Os OpenRC
 .Sh NAME
@@ -59,7 +59,6 @@ Resets the service state to stopped and removes all saved data about the
 service.
 .El
 .Pp
-The following options affect how the service is run:
 .Bl -tag -width "RC_DEFAULTLEVEL"
 .It Fl d , -debug
 Set xtrace on in the shell to assist in debugging.
@@ -79,7 +78,6 @@ Shows which services would be stopped and/or started without actually stopping
 or starting them.
 .El
 .Pp
-The following variables affect the service script:
 .Bl -tag -width "RC_DEFAULTLEVEL"
 .It Ar extra_commands
 Space separated list of extra commands the service defines. These should
@@ -260,7 +258,46 @@ which will export
 and listen for notifications. At the moment supporting
 .Ar READY=1 Ns .
 .El
-.Pp
+.Ss Default start/stop
+The following table lists all the variables that are used by the
+default start and stop functions.
+.TS
+allbox tab(:);
+ci ci ci ci
+c c c c .
+variable:start-stop-daemon:supervise-daemon:s6
+capabilities:start:start:
+chroot:start:start,stop:start
+command:stop:stop:start
+command_args:::start
+command_args_foreground:::start
+command_user:start:start:start
+directory:start:start:start
+error_log:start:start:start
+error_logger:start:start:start
+healthcheck_delay::start:
+healthcheck_timer::start:
+input_file:start:start:start
+no_new_privs:start:start:
+notify:start:start:start
+output_log:start:start:start
+output_logger:start:start:start
+pidfile:start,stop:start,stop:
+procname:start,stop::
+respawn_delay::start:
+respawn_max::start:
+respawn_period::start:
+retry:stop:start:
+s6_log_arguments:::start
+secbits:start:start:
+stopsig:stop::stop
+supervise_daemon_args::start:
+timeout_down:::stop
+timeout_kill:::stop
+timeout_ready:::start
+umask:start:start:start
+.TE
+.Ss Ambient process capabilities
 The following options affect the ambient capabilities of processes on Linux.
 See
 .Xr capabilities 7 .


### PR DESCRIPTION
Obsoletes #771; initial pass.

i've created the table under an `Ss` ('Subsection') macro, rather than under an `Sh` macro, which is intended to be used for a higher-level standard manual section headings, as described in [mdoc(7)'s "MANUAL STRUCTURE" section](https://man.openbsd.org/mdoc.7#MANUAL_STRUCTURE) (neither groff_man(7) nor groff_man_style(7) provide such a description). In this case, i've added the subsection heading "Default start/stop" within "DESCRIPTION", which has necessitated using another `Ss` macro to clearly separate it from a following subsection, "Ambient process capabilities".

To test the output with groff, do:

```
$ groff -mdoc -t -Tutf8 ./openrc-run.8 | less -L
```

(The `-T` option specifies the output format; other possible options include `ascii` and `latin1`.)

To test the output with mandoc, do:

```
$ mandoc -a ./openrc-run.8
```

The contents of the table are based on:

* my original PR;
* [the example content provided by @N-R-K](https://github.com/OpenRC/openrc/pull/771#issuecomment-2791430890), which might not have been intended to be taken as literal content, only as example filler;
* references to supervise-daemon in the existing option list.

i'm not sure what to consult to find all the appropriate content for the `supervise-daemon` and `s6` columns. (For context, i'm the porter of the HTML documentation for various skaware projects to mdoc(7) -  s6-man-pages, s6-rc-man-pages, etc. - although i'm currently in the process of transferring maintainership of these ports to someone else.)

In terms of formatting:

* i've simply requested 'centering' of text in data cells, via the third line after the `TS` macro (i.e. the one ending in a full stop, `.`). To test out other possibilities, refer to [tbl(7)'s "Layout" section](https://mandoc.bsd.lv/man/tbl.7.html#Layout).
* i initially tried using the tbl(7)  `doublebox` / `doubleframe` options to create a more substantial outline for the edges of the table, but the output was clearly unsatisfactory. (Add `doubleframe` to the start of the first line after the `TS` macro to see what i mean.)

.... i think that's everything for now!