### PR TITLE
Fix rc.log missing shutdown messages in some cases.

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -69,6 +69,12 @@ stop()
 		no_umounts_r="$no_umounts_r|$x"
 	done
 
+	if yesno ${rc_logger:-NO}; then
+		[ ! -f "${rc_log_path}" ] && touch "${rc_log_path}"
+		local rc_log_mntpnt=$(stat --format %m "${rc_log_path}")
+		no_umounts_r="$no_umounts_r|${rc_log_mntpnt}"
+	fi
+
 	if [ "$RC_UNAME" = Linux ]; then
 		no_umounts_r="$no_umounts_r|/proc|/proc/.*|/run|/sys|/sys/.*"
 		if [ -e "$rc_svcdir"/usr_premounted ]; then


### PR DESCRIPTION
Fix rc.log missing shutdown messages if located on separate (non-root) file system by preventing localmount from unmouting this file system to early keeping rc.log file writible.

Closes: https://github.com/OpenRC/openrc/issues/977