### PR TITLE
shared: fix fcntl argument order

### DIFF
--- a/src/shared/helpers.h
+++ b/src/shared/helpers.h
@@ -288,7 +288,7 @@ RC_UNUSED static char *env_findvar(const char *name, char **envp)
 RC_UNUSED static int xopen_nonblock(const char *filename, int flags, mode_t mode)
 {
 	int fd = open(filename, flags | O_NONBLOCK, mode);
-	if (fd >= 0 && fcntl(F_SETFL, fd, flags & ~O_NONBLOCK) < 0) {
+	if (fd >= 0 && fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0) {
 		int saved_errno = errno;
 		close(fd);
 		fd = -1;


### PR DESCRIPTION
how this managed to survive my tests is beyond me...

fixes: b6db87756c9ae6338bd58c02bdca941adf6db97d