### PR TITLE
bash-completion: add completion for all flags

### DIFF
--- a/bash-completion/openrc
+++ b/bash-completion/openrc
@@ -16,8 +16,26 @@ _openrc()
 	local cur
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	if [[ ${#COMP_WORDS[*]} -le 2 ]]; then
-		COMPREPLY=($(compgen -W "$(rc-status --list)" -- $cur))
+
+	user_flag=
+	non_flag_args=0
+
+	for i in "${COMP_WORDS[@]}"; do
+		case "$i" in
+			--user|-U)
+				user_flag=--user
+				;;
+			-*)
+				;;
+			*)
+				non_flag_args=$((non_flag_args+1))
+				;;
+		esac
+	done
+
+	# runlevel is the second word that is not a flag
+	if [[ $non_flag_args -eq 2 ]]; then
+		COMPREPLY=($(compgen -W "$(rc-status ${user_flag} --list)" -- $cur))
 	fi
 	return 0
 } &&

--- a/bash-completion/rc-service
+++ b/bash-completion/rc-service
@@ -49,18 +49,14 @@ _rc_service()
 		done
 	fi
 
-	if [[ ${COMP_CWORD} -eq 3 ]]; then
-		return 1
-	fi
-
 	# check if an option was typed
 	if [[ ${cur} == -* ]]; then
 		if [[ ${cur} == --* ]]; then
-			opts="--list --exists --resolve"
+			opts="--user --list --exists --resolve --ifcrashed --debug --nodeps --ifexists --ifnotstarted --ifstarted --ifstopped --dry-run"
 			COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 			return 0
 		elif [[ ${cur} == -* ]]; then
-			opts="-l -e -r"
+			opts="-U -l -e -r -c -d -D -i -I -s -S -Z"
 			COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 			return 0
 		fi
@@ -83,30 +79,32 @@ _rc_service()
 
 		return 0
 	else
-		# no option was typed
-		if [[ ${COMP_CWORD} -eq 1 ]]; then			  # if first word typed
+		user_flag=
+
+		for i in "${COMP_WORDS[@]}"; do
+			case "$i" in
+				--user|-U)
+					user_flag=--user
+					;;
+			esac
+		done
+
+		# first non-flag argument
+		if [[ ${COMP_CWORD} -eq 1 ]] || ( [[ ${prev} == -* ]] && [[ ${action} != list ]] ); then
 			# complete for init scripts
-			COMPREPLY=($(for i in $(rc-service --list) ; do \
-				[[ ${i} == "${cur}"* ]] && echo ${i} ; \
-			done))
+			COMPREPLY=($(compgen -W "$(rc-service ${user_flag} --list)" -- "$cur"))
 			return 0
-		elif [[ ${COMP_CWORD} -eq 2 ]] && [[ ${prev} != -* ]]; then # if second word typed and we didn't type in a function
+		# if next argument after a service name
+		elif [[ ${COMP_CWORD} -gt 1 ]] && [[ ${prev} != -* ]] && [[ ${action} == "" ]]; then
 			rc-service --exists "$prev" || return
 			while read -r _ line; do
 				if [[ $line == +([[:alnum:]_]):* ]]; then
 					opts+="${line%%:*} "
 				fi
-			done < <(rc-service "$prev" describe 2>&1)
+			done < <(rc-service "${user_flag}" "$prev" describe 2>&1)
 			COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 			return 0
 		fi
-	fi
-	if [[ ${action} == '--exists' ]] || [[ ${action} == '-e' ]] || \
-		[[ ${action} == '--resolve' ]]  || [[ ${action} == '-r' ]]; then
-		COMPREPLY=($(for i in $(rc-service --list) ; do \
-			[[ ${i} == "${cur}"* ]] && echo ${i} ; \
-		done))
-		return 0
 	fi
 	return 0
 } &&

--- a/bash-completion/rc-status
+++ b/bash-completion/rc-status
@@ -13,19 +13,37 @@
 #
 _rcstatus()
 {
-	local cur
+	local cur prev complete_runlevel user_flag
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	if [[ $COMP_CWORD -eq 1 ]]; then
-		if [[ "${cur}" == --* ]]; then
-			COMPREPLY=($(compgen -W '--all --list --unused' -- ${cur}))
-		elif [[ "${cur}" == -* ]]; then
-			COMPREPLY=($(compgen -W '-a -l -u' -- ${cur}))
-		else
-			COMPREPLY=($(compgen -W "$(rc-status --list)" -- ${cur}))
-		fi
-	else
-		unset COMPREPLY
-	fi
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    complete_runlevel="TRUE"
+    user_flag=""
+
+	for i in "${COMP_WORDS[@]}"; do
+		case "$i" in
+			-a|-m|-S|-s|-u|-c|-l|-r|--all|--manual|--supervised|--servicelist|--unused|--crashed|--list|--runlevel)
+                complete_runlevel="FALSE"
+                ;;
+            -U|--user)
+                user_flag="--user"
+                ;;
+		esac
+	done
+
+    if [[ "${cur}" == --* ]]; then
+        COMPREPLY=($(compgen -W '--all --list --unused --user --crashed --manual --supervised --servicelist --nocolor' -- ${cur}))
+    elif [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W '-a -c -C -l -m -u -U -S -s' -- ${cur}))
+    elif [[ "${prev}" == -f ]] || [[ "${prev}" == --format ]]; then
+        COMPREPLY=($(compgen -W 'ini' -- ${cur}))
+    elif [[ "${prev}" == -i ]] || [[ "${prev}" == --in-state ]]; then
+        states='stopped started stopping starting inactive hotplugged failed scheduled crashed'
+        COMPREPLY=($(compgen -W "${states}" -- ${cur}))
+    elif [[ "${complete_runlevel}" == "TRUE" ]]; then
+        COMPREPLY=($(compgen -W "$(rc-status ${user_flag} --list)" -- ${cur}))
+    else
+        unset COMPREPLY
+    fi
 	return 0
 } &&
 complete -F _rcstatus rc-status

--- a/bash-completion/rc-update
+++ b/bash-completion/rc-update
@@ -13,29 +13,55 @@
 #
 _rc_update()
 {
-	local cur show
+	local cur show stack
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	if [[ $COMP_CWORD -eq 1 ]]; then
-		if [[ "${cur}" == -* ]]; then
-			COMPREPLY=($(compgen -W '-a -d -s' -- ${cur}))
-		else
-			COMPREPLY=($(compgen -W 'add del show' ${cur}))
-		fi
-	else
-		if [[ "${COMP_WORDS[1]}" == "show" ]] || [[ "${COMP_WORDS[1]}" == "-s" ]]; then
-			show="TRUE"
-		fi
-		if ([[ $COMP_CWORD -eq 3 ]] && [[ -z "$show" ]]) || \
-			([[ $COMP_CWORD -eq 2 ]] && [[ -n "$show" ]]); then
-		COMPREPLY=($(compgen -W "$(rc-status --list)" -- $cur))
-		elif [[ $COMP_CWORD -eq 2 ]]; then
-			COMPREPLY=($(compgen -W "$(rc-service --list)" $cur))
-		elif [[ ${#COMP_WORDS[*]} -gt 2 ]] ; then
-			COMPREPLY=($(compgen -W "$(rc-status --list)" -- $cur))
+
+	user_flag=
+	non_flag_args=0
+
+	for i in "${COMP_WORDS[@]}"; do
+		case "$i" in
+			--user|-U)
+				user_flag=--user
+				;;
+			show)
+				show="TRUE"
+				non_flag_args=$((non_flag_args+1))
+				;;
+            -s)
+                stack="TRUE"
+                ;;
+			-*)
+				;;
+			*)
+				non_flag_args=$((non_flag_args+1))
+				;;
+		esac
+	done
+
+	if [[ "${cur}" == --* ]]; then
+		COMPREPLY=($(compgen -W '--all --verbose --update --user' -- ${cur}))
+	elif [[ "${cur}" == -* ]]; then
+		COMPREPLY=($(compgen -W '-a -v -u -U' -- ${cur}))
+	elif [[ ${non_flag_args} -eq 2 ]]; then
+		COMPREPLY=($(compgen -W 'add del show' ${cur}))
+	elif [[ "${show}" == "TRUE" ]]; then
+		if [[ ${non_flag_args} -eq 3 ]]; then
+			COMPREPLY=($(compgen -W "$(rc-status ${user_flag} --list)" -- "$cur"))
 		else
 			unset COMPREPLY
 		fi
+	elif [[ ${non_flag_args} -eq 3 ]]; then
+        if [[ "${stack}" == "TRUE" ]]; then
+            COMPREPLY=($(compgen -W "$(rc-status ${user_flag} --list)" -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W "$(rc-service ${user_flag} --list)" -- "$cur"))
+        fi
+	elif [[ ${non_flag_args} -gt 3 ]] ; then
+		COMPREPLY=($(compgen -W "$(rc-status ${user_flag} --list)" -- "$cur"))
+	else
+		unset COMPREPLY
 	fi
 	return 0
 } &&


### PR DESCRIPTION
adds bash completion for all current flags and notably for user service/runlevels.

rc-update’s completion script seemed to consider -s (--stack) to be equivalent to the show command which is fixed in this commit.

I’ve been using a variation of this current PR for user service/runlevel completions which seems to worked as expected and just got around to adding completion for the missing flags.