### PR TITLE
consolefont: allow passing extra arguments to setfont

### DIFF
--- a/conf.d/consolefont
+++ b/conf.d/consolefont
@@ -16,3 +16,7 @@ consolefont="default8x16"
 # default one. Have a look in /usr/share/unimaps for a selection of map files
 # you can use.
 #unicodemap="iso01"
+
+# customflags is used to pass custom arguments to the setfont command;
+# e.g. "-d" for doubling the font size on high pixel density displays.
+#customflags=""

--- a/init.d/consolefont.in
+++ b/init.d/consolefont.in
@@ -24,6 +24,7 @@ start()
 	consolefont=${consolefont:-${CONSOLEFONT}}
 	unicodemap=${unicodemap:-${UNICODEMAP}}
 	consoletranslation=${consoletranslation:-${CONSOLETRANSLATION}}
+	customflags=${customflags:-${CUSTOMFLAGS}}
 
 	if [ -z "$consolefont" ]; then
 		ebegin "Using the default console font"
@@ -52,7 +53,7 @@ start()
 	[ -d /dev/vc ] && ttydev=/dev/vc/
 	x=1
 	while [ $x -le $ttyn ]; do
-		if ! setfont $consolefont $param -C $ttydev$x >/dev/null; then
+		if ! setfont $customflags $consolefont $param -C $ttydev$x >/dev/null; then
 			retval=1
 			break
 		fi


### PR DESCRIPTION
**Summary**

This change introduces support for an optional `customflags` variable in `/etc/conf.d/consolefont`, allowing users to pass additional arguments to the `setfont` command.

**Motivation**

Currently, the `consolefont` OpenRC service does not provide a way to customize the arguments passed to `setfont`. Users who need non-default behavior (for example, using the `-d` flag for double-size fonts) must modify `/etc/init.d/consolefont` directly.

Since this file is owned by the package, such changes are overwritten on upgrade, forcing users to rely on fragile workarounds such as patching via package manager hooks.

**Proposed solution**

Introduce a new optional variable:

`customflags=""`

This variable is sourced from `/etc/conf.d/consolefont` and appended to the `setfont` invocation:

`setfont $customflags $consolefont $param -C $ttydev$x >/dev/null`

**Benefits**
- Enables customization without modifying init scripts
- Preserves existing default behavior when unset
- Aligns with existing OpenRC patterns of exposing command arguments via `/etc/conf.d/*`
- Eliminates the need for downstream patching or hooks

**Backward compatibility**

No changes in behavior for existing users. If `customflags` is unset or empty, the command behaves exactly as before.

**Example usage**

To enable double-size console fonts:

`consolefont="Lat2-Terminus16"`
`customflags="-d"`