### PR TITLE
fix: tools/meson_final.sh lowercase linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ core
 .gdbinit
 
 build
+
+# IDE
+.idea

--- a/tools/meson_final.sh
+++ b/tools/meson_final.sh
@@ -6,7 +6,7 @@ set -u
 rc_libexecdir="$1"
 os="$2"
 
-if [ "${os}" != Linux ]; then
+if [ "${os}" != linux ]; then
 	install -d "${DESTDIR}/${rc_libexecdir}"/init.d
 fi
 install -m 644 "${MESON_BUILD_ROOT}/src/shared/version" "${DESTDIR}/${rc_libexecdir}"


### PR DESCRIPTION
~~DESTDIR doesn't make sense to me because rc_libexecdir is already absolute path because it depends on the get_option('prefix')~~

Just a linux lowercase fix