### PR TITLE
openrc-init: use sbindir instead of hard-coded /sbin for PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,24 @@ file systems and expects / to be mounted before /usr, you will need to
 make sure the appropriate pieces are installed on / by passing the
 appropriate options to "meson setup" as follows:
 
-```
+```shell
 $ meson setup \
         --bindir /bin --libdir /lib64 --libexecdir /lib --sbindir /sbin \
-        build_path
+        build
 ```
+### Custom openrc directory
+
+If you want to install openrc into a custom directory such as /opt/openrc
+```shell
+$ CUSTOM_PREFIX=/opt/openrc && meson setup 
+  --prefix="$CUSTOM_PREFIX" --bindir=bin --sbindir=sbin --sysconfdir="$CUSTOM_PREFIX/etc" \
+  build
+```
+After, setting it up install openrc by this command. 
+```shell
+$ meson install --destdir='' -C build
+```
+In our case, openrc is going to be correctly installed at /opt/openrc
 
 ## Discussions
 

--- a/src/librc/meson.build
+++ b/src/librc/meson.build
@@ -4,6 +4,13 @@ rc_h_conf_data.set('RC_PLUGINDIR', pluginsdir)
 rc_h_conf_data.set('LOCAL_PREFIX', local_prefix)
 rc_h_conf_data.set('PKG_PREFIX', pkg_prefix)
 rc_h_conf_data.set('SYSCONFDIR', get_option('sysconfdir'))
+rc_h_conf_data.set('SBINDIR', sbindir)
+
+rc_init_bindir = bindir
+if rc_init_bindir != '/bin'
+  rc_init_bindir += ':/bin'
+endif
+rc_h_conf_data.set('RC_INIT_BINDIR', rc_init_bindir)
 
 librc_sources = [
   'librc.c',

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -38,6 +38,7 @@ extern "C" {
 #define RC_PLUGINDIR            "@RC_PLUGINDIR@"
 
 #define RC_INIT_FIFO RC_SVCDIR"/init.ctl"
+#define RC_INIT_DEFAULT_PATH "@SBINDIR@:/usr/sbin:@RC_INIT_BINDIR@:/usr/bin"
 #define RC_PROFILE_ENV     RC_SYSCONFDIR "/profile.env"
 #define RC_SYS_WHITELIST   RC_LIBEXECDIR "/conf.d/env_whitelist"
 #define RC_USR_WHITELIST   RC_SYSCONFDIR "/conf.d/env_whitelist"

--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -51,7 +51,6 @@
 #  define CLOCK_MONOTONIC CLOCK_BOOTTIME
 #endif
 
-static const char *path_default = "/sbin:/usr/sbin:/bin:/usr/bin";
 static const char *rc_default_runlevel = "default";
 static int sigpipe[2] = { -1, -1 };
 static bool quiet = false;
@@ -368,8 +367,10 @@ int main(int argc, char **argv)
 #endif
 	reboot(RB_DISABLE_CAD);
 
+	if (!quiet)
+		printf("Setting environment PATH to %s\n", RC_INIT_DEFAULT_PATH);
 	/* set default path */
-	setenv("PATH", path_default, 1);
+	setenv("PATH", RC_INIT_DEFAULT_PATH, 1);
 
 	if (!reexec)
 		init(cmdline_runlevel);


### PR DESCRIPTION
This PR fixes the hard-coded part of /sbin default path. Moved the path_default var to rc.h.in macro as was suggested in the comment below. This issue was hard to find so I added one more log that can be useful because you just see this `do_exec: No such file or directory` without any context

Also, the issue was addressed here  https://github.com/OpenRC/openrc/pull/205#issuecomment-2728050827
