### PR TITLE
Document the --user/-U option in manpage

### DIFF
--- a/man/openrc.8
+++ b/man/openrc.8
@@ -87,6 +87,8 @@ Display software version.
 Run verbosely.
 .It Fl q , -quiet
 Run quietly (repeat to suppress errors).
+.It Fl U , -user
+Run in user mode.
 .El
 .Sh SEE ALSO
 .Xr openrc-run 8 ,


### PR DESCRIPTION
The `--user`/`-U` option used for user services appears absent from all section 8 manual pages, while it is present in the `--help` message:

```console
$ rc-service --help | grep U
Usage: rc-service [options] [-i] <service> <cmd>...
Options: [ cdDe:ilr:INsSZChqVvU ]
  -U, --user                        Run in user mode

$ openrc --help | grep U
Usage: openrc [options] [<runlevel>]
Options: [ a:no:s:SChqVvU ]
  -U, --user                        Run in user mode
```

So I figured we should copy this into the manpage, similar to the methodology taken in #378...

Though because `-U` is a common option like `-ChqVv`, I added it to **openrc**(8) where the latter five options are already documented. I placed it at the end which is consistent with the order of `getoptstring_COMMON` and the `--help` message.
