### PR TITLE
libeinfo: add xterm-ghostty to color_terms

### DIFF
--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -135,6 +135,7 @@ static const char *const color_terms[] = {
 	"xterm",
 	"xterm-debian",
 	"xterm-kitty",
+    "xterm-ghostty",
 	NULL
 };
 


### PR DESCRIPTION
Add `xterm-ghostty` to `color_terms` in [src/libeinfo/libeinfo.c](https://github.com/OpenRC/openrc/blob/master/src/libeinfo/libeinfo.c), closing #1017 