### PR TITLE
rework on rc_service_*env api

### DIFF
--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -1345,97 +1345,76 @@ rc_services_scheduled(const char *service)
 }
 
 bool
-rc_service_setenv(const char *service, const char *const env[])
+rc_service_putenv(const char *service, const char *env)
 {
+	size_t name_len = strcspn(env, "=");
+	char var[strlen(service) + sizeof("/") + name_len];
+	int dfp = rc_dirfd(RC_DIR_ENVIRON);
 	FILE *fp;
 
-	for (const char *const *var = env; *var; var++)
-		if (!strchr(*var, '='))
-			return errno = EINVAL, false;
+	if (env[name_len] != '=')
+		return errno = EINVAL, false;
 
-	if (!(fp = do_fopenat(rc_dirfd(RC_DIR_ENVIRON), service, O_WRONLY | O_CREAT | O_TRUNC)))
+	snprintf(var, sizeof(var), "%s/%.*s", service, (int) name_len, env);
+
+	if (mkdirat(dfp, service, 0700) == -1 && errno != EEXIST)
 		return false;
 
-	for (const char *const *var = env; *var; var++)
-		if (fprintf(fp, "%s%c", *var, '\0') == -1)
-			return fclose(fp), false;
+	if (!(fp = do_fopenat(dfp, var, O_WRONLY | O_CREAT | O_TRUNC)))
+		return false;
+
+	fputs(&env[name_len + 1], fp);
 
 	return fclose(fp) == 0;
 }
 
 bool
-rc_service_getenv(const char *service, struct rc_environ *env)
+rc_service_setenv(const char *service, const char *name, const char *value)
 {
-	size_t end = env->size, count = 0;
-	struct stat stat;
-	char *envstr;
-	int serrno;
+	char var[strlen(service) + sizeof("/") + strlen(name)];
+	int dfp = rc_dirfd(RC_DIR_ENVIRON);
 	FILE *fp;
 
-	if (!(fp = do_fopenat(rc_dirfd(RC_DIR_ENVIRON), service, O_RDONLY)))
-		return errno == ENOENT;
+	snprintf(var, sizeof(var), "%s/%s", service, name);
 
-	if (fstat(fileno(fp), &stat) == -1)
-		goto err;
+	if (mkdirat(dfp, service, 0700) == -1 && errno != EEXIST)
+		return false;
 
-	if (!(envstr = xrealloc(env->bytes, env->size + stat.st_size)))
-		goto err;
-	env->bytes = envstr;
+	if (!(fp = do_fopenat(dfp, var, O_WRONLY | O_CREAT | O_TRUNC)))
+		return false;
 
-	if (fread(&env->bytes[end], 1, stat.st_size, fp) < (size_t) stat.st_size)
-		goto err;
-	env->size += stat.st_size;
-	env->bytes[env->size - 1] = '\0';
+	fputs(value, fp);
+
+	return fclose(fp) == 0;
+}
+
+ssize_t
+rc_service_getenv(const char *service, const char *name, char **buf)
+{
+	char var[strlen(service) + sizeof("/") + strlen(name)], *value;
+	int serrno, dfd = rc_dirfd(RC_DIR_ENVIRON);
+	struct stat stat;
+	size_t count;
+	FILE *fp;
+
+	snprintf(var, sizeof(var), "%s/%s", service, name);
+
+	if (fstatat(dfd, var, &stat, 0) == -1)
+		return -1;
+
+	if (!buf)
+		return stat.st_size;
+
+	if (!(value = xrealloc(*buf, stat.st_size + 1)))
+		return -1;
+
+	if (!(fp = do_fopenat(dfd, var, O_RDONLY)))
+		return -1;
+
+	count = fread(value, 1, stat.st_size, fp);
+	value[count] = '\0';
 
 	fclose(fp);
-
-	for (off_t i = 0; i < stat.st_size; i += strlen(&env->bytes[end + i]) + 1) {
-		if (!strchr(&env->bytes[i], '='))
-			return env->size = end, errno = EINVAL, false;
-		count++;
-	}
-
-	env->count += count;
-	return true;
-
-err:
-	serrno = errno;
-	fclose(fp);
-	errno = serrno;
-	return false;
-}
-
-void
-rc_environ_merge(const struct rc_environ *env, const char *const defaults[], size_t envp_size, const char *envp[static envp_size])
-{
-	size_t i = 0;
-	if (defaults) for (; i < envp_size - 1 && defaults[i]; i++)
-		envp[i] = defaults[i];
-	envp[i] = NULL;
-
-	for (size_t pos = 0; pos < env->size; pos += strlen(&env->bytes[pos]) + 1)
-		env_putenv(&env->bytes[pos], envp_size, envp);
-}
-
-size_t
-rc_environ_export(const struct rc_environ *env, const char *const defaults[], const char ***envp_out)
-{
-	const char **envp;
-	size_t size = 0;
-
-	if (defaults) while (defaults[size])
-		size++;
-
-	size += env->count + 1;
-	envp = xmalloc(sizeof(*envp) * size);
-
-	rc_environ_merge(env, defaults, size, envp);
-	*envp_out = envp;
-	return size;
-}
-
-void
-rc_environ_free(struct rc_environ *env)
-{
-	env->bytes = (free(env->bytes), NULL);
+	*buf = value;
+	return count;
 }

--- a/src/librc/rc.h.in
+++ b/src/librc/rc.h.in
@@ -380,54 +380,27 @@ RC_STRINGLIST *rc_services_scheduled(const char *);
  * @return true if all daemons started are still running, otherwise false */
 bool rc_service_daemons_crashed(const char *);
 
-/*! structure for environment data, to be populated by rc_service_getenv,
- * and applied to an array via rc_environ_merge or rc_env_export.
- *
- * rc_environ.bytes is heap allocated and holds a sequence of rc_env.count
- * nul-delimited strings, up to rc_environ.bytes
- *
- * this structure should be zero-initialized before use, and free'd with
- * rc_environ_free.
- * */
-struct rc_environ {
-	char *bytes;
-	size_t size, count;
-};
+/*! Sets the shared enviroment for 'service'.
+ * @param service name
+ * @param variable name
+ * @param variable value
+ * @return true on success, false on IO error. */
+bool rc_service_setenv(const char *, const char *, const char *);
 
 /*! Sets the shared enviroment for 'service'.
  * @param service name
- * @param null terminated environment variable array in NAME=VALUE format.
+ * @param k=v variable
  * @return true on success, false on IO error. */
-bool rc_service_setenv(const char *, const char *const []);
+bool rc_service_putenv(const char *, const char *);
 
 /*! Reads the environment file of the service, as a sequence of null terminated
  * strings, reallocating `env->bytes` appending the new variables to the end, then updating
  * `env->size` and `env->count`.
  * Variable names may be repeated in env->bytes, in which case the last entry should be used.
  * @param serivce name.
- * @param environment string to append
- * @return number of variables exported. */
-bool rc_service_getenv(const char *, struct rc_environ *);
-
-/*! Parses the environment string held by environ into an environment array, using
- * the values of 'default' as a base.
- * @param environment string to parse
- * @param default variables to initialize envp
- * @param size of output environment
- * @param output environment */
-void rc_environ_merge(const struct rc_environ *, const char *const [], size_t size, const char *envp[static size]);
-
-/*! Parses the environment string held by environ into an environment array, using
- * the values of 'default' as a base.
- * @param environment string to parse
- * @param default variables to populate
- * @param out pointer to store resulting heap allocated array
- * @return number of variables in resulting array */
-size_t rc_environ_export(const struct rc_environ *, const char *const [], const char ***);
-
-/*! frees env->bytes
- * @param env */
-void rc_environ_free(struct rc_environ *);
+ * @param pointer to NULL or malloc-allocated line buffer
+ * @return lenght of the variable or -1 on failure */
+ssize_t rc_service_getenv(const char *, const char *, char **);
 
 /*! @name System types
  * OpenRC can support some special sub system types, normally virtualization.

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -98,7 +98,6 @@ static bool in_background, deps, dry_run;
 static volatile bool sighup, skip_mark, timedout;
 static pid_t service_pid;
 static int signal_pipe[2] = { -1, -1 };
-static struct rc_environ env;
 
 static RC_STRINGLIST *deptypes_b;	/* broken deps */
 static RC_STRINGLIST *deptypes_n;	/* needed deps */
@@ -239,7 +238,6 @@ cleanup(void)
 
 	rc_plugin_unload();
 
-	rc_environ_free(&env);
 	rc_stringlist_free(deptypes_b);
 	rc_stringlist_free(deptypes_n);
 	rc_stringlist_free(deptypes_nw);
@@ -259,6 +257,22 @@ cleanup(void)
 	free(prefix);
 	free(runlevel);
 	free(service);
+}
+
+static void
+svc_getenv(const char *svc)
+{
+	RC_STRINGLIST *reexports = rc_deptree_depend(deptree, svc, "reexport");
+	RC_STRING *reexport;
+	char *var = NULL;
+
+	TAILQ_FOREACH(reexport, reexports, entries) {
+		if (rc_service_getenv(svc, reexport->value, &var) == -1)
+			continue;
+		setenv(reexport->value, var, true);
+	}
+
+	free(var);
 }
 
 /* Buffer and lock all output messages so that we get readable content */
@@ -338,7 +352,6 @@ svc_exec(const char *command)
 	sigset_t sigchldmask;
 	sigset_t oldmask;
 	char *openrc_sh = NULL;
-	const char **envp = NULL;
 	const char *argv[] = {
 		RC_LIBEXECDIR "/sh/openrc-run.sh",
 		service,
@@ -388,18 +401,14 @@ svc_exec(const char *command)
 		argv[0] = openrc_sh;
 	}
 
-	if (env.count)
-		rc_environ_export(&env, (const char *const *) environ, &envp);
-
 	einfov("Executing: %s %s %s", argv[0], service, command);
-	if ((errno = posix_spawn(&service_pid, argv[0], &tty, NULL, UNCONST(argv), envp ? UNCONST(envp) : environ))) {
+	if ((errno = posix_spawn(&service_pid, argv[0], &tty, NULL, UNCONST(argv), environ))) {
 		eerror("%s: exec '%s': %s", service, argv[0], strerror(errno));
 		return 1;
 	}
 
 	posix_spawn_file_actions_destroy(&tty);
 	free(openrc_sh);
-	free(envp);
 
 	fd[0].fd = signal_pipe[0];
 	fd[1].fd = master_tty;
@@ -675,7 +684,7 @@ svc_start_deps(void)
 	TAILQ_FOREACH(svc, services, entries) {
 		state = rc_service_state(svc->value);
 		if (state & RC_SERVICE_STARTED) {
-			rc_service_getenv(svc->value, &env);
+			svc_getenv(svc->value);
 			continue;
 		}
 
@@ -693,7 +702,7 @@ svc_start_deps(void)
 			eerror("%s: timed out waiting for %s", applet, svc->value);
 		state = rc_service_state(svc->value);
 		if (state & RC_SERVICE_STARTED) {
-			rc_service_getenv(svc->value, &env);
+			svc_getenv(svc->value);
 			continue;
 		}
 		if (rc_stringlist_find(need_services, svc->value)) {
@@ -981,7 +990,7 @@ load_dep_env(void)
 	depsvcs = rc_deptree_depends(deptree, deptypes_nwu, applet_list, runlevel, 0);
 
 	TAILQ_FOREACH(svc, depsvcs, entries)
-		rc_service_getenv(svc->value, &env);
+		svc_getenv(svc->value);
 
 	rc_stringlist_free(services);
 }

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -764,9 +764,6 @@ static void set_reexports(void)
 	char *buf;
 	FILE *fp;
 
-	if (TAILQ_EMPTY(list))
-		goto out;
-
 	fp = xopen_memstream(&buf, &size);
 
 	fputs("RC_REEXPORT=", fp);
@@ -775,7 +772,6 @@ static void set_reexports(void)
 
 	fclose(fp);
 	putenv(buf);
-out:
 	rc_stringlist_free(list);
 }
 

--- a/src/rc-environ/rc-environ.c
+++ b/src/rc-environ/rc-environ.c
@@ -3,6 +3,7 @@
 #include <getopt.h>
 #include <rc.h>
 #include <queue.h>
+#include <string.h>
 
 #include "_usage.h"
 #include "helpers.h"
@@ -28,6 +29,41 @@ const char *const longopts_help[] = {
 	"Add services in runlevel to the list of environments to print",
 	longopts_help_COMMON
 };
+
+static int
+set_environment(const char *service, char *vars[])
+{
+	RC_DEPTREE *deptree = _rc_deptree_load(0, NULL);
+	RC_STRINGLIST *reexports = rc_deptree_depend(deptree, service, "reexport");
+	RC_STRING *reexport;
+
+	if (!(rc_service_state(service) & RC_SERVICE_STARTING)) {
+		eerror("service %s is not in the starting state", service);
+		return 1;
+	}
+
+	for (const char *var; (var = *vars); vars++) {
+		const char *var = *vars++;
+		size_t name_len = strcspn(var, "=");
+
+		TAILQ_FOREACH(reexport, reexports, entries) {
+			if (strncmp(reexport->value, var, name_len) != 0)
+				continue;
+			if (var[name_len] == '=')
+				rc_service_putenv(service, var);
+			else
+				rc_service_setenv(service, var, getenv(var));
+			goto next;
+		}
+
+		ewarn("service %s does not reexport %.*s, skipping", service, (int)name_len, var);
+next:;
+	}
+
+	rc_stringlist_free(reexports);
+	rc_deptree_free(deptree);
+	return 0;
+}
 
 static void escape_variable(const char *value) {
 	char ch;
@@ -129,8 +165,8 @@ int main(int argc, char **argv) {
 	argc -= optind;
 	argv += optind;
 
-	if (argc)
-		usage(EXIT_FAILURE);
+	if (!argc)
+		return print_environment(services, escape, export, sep);
 
-	return print_environment(services, escape, export, sep);
+	return set_environment(argv[0], &argv[1]);
 }

--- a/src/rc-environ/rc-environ.c
+++ b/src/rc-environ/rc-environ.c
@@ -62,37 +62,41 @@ print_environment(RC_STRINGLIST *services, bool escape, bool export, char sep)
 {
 	/* from POSIX.2024 Shell Command Language 2.2, excluding `=` */
 	static const char special_chars[] = "|&;<>()$`\\\"' \t\n*?[]^-!#~%{},";
-	struct rc_environ env = {0};
+	RC_DEPTREE *deptree = _rc_deptree_load(0, NULL);
 	RC_STRING *service;
-	const char **envp;
+	char *value = NULL;
 	int ret = 0;
 
 	if (!services)
 		services = rc_services_in_state(RC_SERVICE_STARTED);
 
 	TAILQ_FOREACH(service, services, entries) {
-		if (!rc_service_getenv(service->value, &env)) {
-			ewarn("%s: failed to read environment for '%s': %s", applet, service->value, strerror(errno));
-			ret = 1;
+		RC_STRINGLIST *reexports = rc_deptree_depend(deptree, service->value, "reexport");
+		RC_STRING *reexport;
+
+		TAILQ_FOREACH(reexport, reexports, entries) {
+			if (rc_service_getenv(service->value, reexport->value, &value) == -1) {
+				ewarn("%s: failed to read variable '%s' for '%s': %s",
+					applet, reexport->value, service->value, strerror(errno));
+				ret = 1;
+				continue;
+			}
+
+			if (export)
+				fputs("export ", stdout);
+			printf("%s=", reexport->value);
+			if (escape && strpbrk(value, special_chars))
+				escape_variable(value);
+			else
+				fputs(value, stdout);
+			fputc(sep, stdout);
 		}
+
+		rc_stringlist_free(reexports);
 	}
 
-	rc_environ_export(&env, NULL, &envp);
-
-	for (size_t i = 0; envp[i]; i++) {
-		int name_len = strcspn(envp[i], "=");
-		const char *value = &envp[i][name_len + 1];
-
-		printf("%s%.*s=", export ? "export " : "", name_len, envp[i]);
-
-		if (escape && strpbrk(value, special_chars))
-			escape_variable(value);
-		else
-			fputs(value, stdout);
-		fputc(sep, stdout);
-	}
-
-	free(envp), rc_environ_free(&env);
+	free(value);
+	rc_deptree_free(deptree);
 	return ret;
 }
 

--- a/src/shared/helpers.h
+++ b/src/shared/helpers.h
@@ -237,44 +237,6 @@ RC_UNUSED static ssize_t xgetline(char **restrict lineptr, size_t *restrict n, F
 	return ret;
 }
 
-RC_UNUSED static bool env_putenv(const char *var, size_t size, const char *env[static size]) {
-	size_t var_idx, last = size - 1, name_len = strcspn(var, "=");
-
-	if (!var[name_len])
-		return false;
-
-	for (var_idx = 0; env[var_idx] && var_idx < last; var_idx++)
-		if (strncmp(var, env[var_idx], name_len) == 0)
-			break;
-
-	if (var_idx == last)
-		return false;
-
-	if (!env[var_idx])
-		env[var_idx + 1] = NULL;
-	env[var_idx] = var;
-
-	return true;
-}
-
-RC_UNUSED static bool env_unsetenv(const char *var, size_t size, const char *env[static size]) {
-	size_t last = size - 1;
-
-	if (strchr(var, '='))
-		return false;
-
-	for (size_t i = 0; i < last && env[i]; i++) {
-		if (strcmp(var, env[i]) != 0)
-			continue;
-		env[i] = env[last];
-		env[last] = NULL;
-
-		return true;
-	}
-
-	return false;
-}
-
 RC_UNUSED static char *env_findvar(const char *name, char **envp)
 {
 	size_t len = strlen(name);

--- a/src/value/value.c
+++ b/src/value/value.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
 	char *service = getenv("RC_SVCNAME");
 	enum { GET, SET, EXPORT } action;
 	char *option = NULL;
-	int envidx = 0;
 
 	applet = basename_c(argv[0]);
 	if (service == NULL)
@@ -61,15 +60,14 @@ int main(int argc, char **argv)
 		return rc_service_value_set(service, argv[1], argv[2]) ? EXIT_SUCCESS : EXIT_FAILURE;
 	case EXPORT:
 		for (int i = 1; i < argc; i++) {
-			char *var = env_findvar(argv[i], environ);
-			if (var)
-				argv[envidx++] = var;
+			char *var;
+			if (rc_service_getenv(service, argv[i], NULL) > 0)
+				continue;
+			else if ((var = getenv(argv[i])))
+				rc_service_setenv(service, argv[i], var);
 			else
 				ewarn("%s: Missing reexport variable '%s'", service, argv[i]);
 		}
-		argv[envidx] = NULL;
-
-		rc_service_setenv(service, (const char *const *) argv);
 		return EXIT_SUCCESS;
 	}
 }


### PR DESCRIPTION
the original api was made before we settled on reexport

having the reexport list makes it simpler and cleaner to handle
exported variabes one-at-a-time over as a block, and allow us to
trivially enforce that only the reexported list are loaded into
dependees

also, it's more intuitive as it matches what libc's getenv/setenv looks like