### PR TITLE
Add default reload function

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -8,7 +8,7 @@
 .\" This file may not be copied, modified, propagated, or distributed
 .\"    except according to the terms contained in the LICENSE file.
 .\"
-.Dd February 14, 2026
+.Dd July 1, 2026
 .Dt openrc-run 8 SMM
 .Os OpenRC
 .Sh NAME
@@ -51,6 +51,9 @@ Stops and starts the service, including dependencies. This cannot be
 overridden. See the description of the RC_CMD variable below for the
 method to make your service behave differently when restart is being
 executed.
+.It Ar reload
+Sends a signal to the service to reload its configuration. The signal to
+send is defined by the reloadsig variable.
 .It Ar status
 Shows the status of the service. The return code matches the status, with the
 exception of "started" returning 0 to match standard command behaviour.
@@ -207,6 +210,8 @@ Pidfile to use for the above defined command.
 Display name used for the above defined command.
 .It Ar procname
 Process name to match when signaling the daemon.
+.It Ar reloadsig
+Signal to send when reloading the daemon.
 .It Ar stopsig
 Signal to send when stopping the daemon.
 If using

--- a/service-script-guide.md
+++ b/service-script-guide.md
@@ -103,6 +103,7 @@ All service scripts are assumed to have the following functions:
 ```
 start()
 stop()
+reload()
 status()
 ```
 
@@ -117,6 +118,7 @@ script:
 command=
 command_args=
 pidfile=
+reloadsig=
 ```
 
 Thus the 'smallest' service scripts can be half a dozen lines long
@@ -131,6 +133,7 @@ following OpenRC variables are likely all that you'll need:
   * command
   * command_args
   * pidfile
+  * reloadsig
 
 Given those three pieces of information, OpenRC will be able to start
 and stop the daemon on its own. The following is taken from an
@@ -242,7 +245,17 @@ To recap, in order of preference:
 
 Many daemons will reload their configuration files in response to a
 signal. Suppose your daemon will reload its configuration in response
-to a `SIGHUP`. It's possible to add a new "reload" command to your
+to a `SIGHUP`. You can simply add the following to your service script:
+
+```sh
+reloadsig=HUP
+```
+
+For most daemons this is sufficient, though note it only works on OpenRC TODO.
+(older versions need a custom `reload()` function, see below)
+
+If this approach is not enough, or the daemon has a completely different
+way of reloading, it's still possible to add a new "reload" command to your
 service script that performs this action. First, tell the service
 script about the new command.
 

--- a/sh/openrc-run.sh.in
+++ b/sh/openrc-run.sh.in
@@ -205,13 +205,16 @@ default_status()
 
 default_reload()
 {
+	local func=ssd_reload
 	case "$supervisor" in
-		s6) s6_reload ;;
+		s6) func=s6_reload ;;
+		supervise-daemon) func=supervise_reload ;;
 		?*)
 			eerror "$RC_SVCNAME: undefined function 'reload'"
 			exit 1
 			;;
 	esac
+	$func
 }
 
 # Template start / stop / status functions
@@ -380,7 +383,7 @@ if yesno $IN_BACKGROUND; then
 	done
 fi
 
-for _cmd in $extra_started_commands; do
+for _cmd in reload $extra_started_commands; do
 	[ "$_cmd" = "$_func" ] || continue
 	if verify_boot && ! service_started; then
 		eerror "$RC_SVCNAME: cannot '$_func' as it has not been started"

--- a/sh/start-stop-daemon.sh
+++ b/sh/start-stop-daemon.sh
@@ -105,6 +105,33 @@ ssd_stop()
 	eend $? "Failed to stop ${name:-$RC_SVCNAME}"
 }
 
+ssd_reload()
+{
+	if [ -n $reloadsig ]; then
+		eerror "There is nothing for ${name:-$RC_SVCNAME} to reload."
+		return 0
+	fi
+
+	local _progress=
+	local startchroot="$(service_get_value "chroot")"
+	local startpidfile="$(service_get_value "pidfile")"
+	local startprocname="$(service_get_value "procname")"
+	chroot="${startchroot:-$chroot}"
+	pidfile="${startpidfile:-$pidfile}"
+	procname="${startprocname:-$procname}"
+	[ -n "$command" -o -n "$procname" -o -n "$pidfile" ] || return 0
+	yesno "${command_progress}" && _progress=--progress
+
+	ebegin "Reloading ${name:-$RC_SVCNAME}"
+	start-stop-daemon \
+		${procname:+--name} $procname \
+		${pidfile:+--pidfile} $chroot$pidfile \
+		--signal ${reloadsig} \
+		${_progress}
+
+	eend $? "Failed to reload ${name:-$RC_SVCNAME}"
+}
+
 ssd_status()
 {
 	_status

--- a/sh/supervise-daemon.sh
+++ b/sh/supervise-daemon.sh
@@ -82,6 +82,19 @@ supervise_stop()
 	eend $? "Failed to stop ${name:-$RC_SVCNAME}"
 }
 
+supervise_reload()
+{
+	if [ -n $reloadsig ]; then
+		eerror "There is nothing for ${name:-$RC_SVCNAME} to reload."
+		return 0
+	fi
+
+	local startchroot="$(service_get_value "chroot")"
+	local startpidfile="$(service_get_value "pidfile")"
+	ebegin "Reloading ${name:-$RC_SVCNAME}"
+	supervise-daemon "${RC_SVCNAME}" --signal $reloadsig
+}
+
 _check_supervised()
 {
 	local child_pid start_time


### PR DESCRIPTION
Historically, reload was meant to be implemented by the service script. However in the end it seems most service scripts just send a signal by calling `start-stop-daemon` directly, something that can easily be done as a default and would reduce duplication.

Add default reload functions for both supervise-daemon and start-stop-daemon, which just send a signal to a service. The signal to send is configured by just setting:

```sh
reloadsig=USR1  # signal to send to trigger reload
```

For service scripts that need to do other things on reload, they can define their own reload function just like before.