### PR TITLE
Further document stacked runlevels 

### DIFF
--- a/man/openrc-run.8
+++ b/man/openrc-run.8
@@ -344,9 +344,11 @@ to the runlevel.
 The service will attempt to start any services it wants, regardless of
 whether they have been added to the runlevel.
 .It Ic after
-The service will start after these services and stop before these services.
+The service will start after these services and stop before these services, if
+they have been added to the runlevel.
 .It Ic before
-The service will start before these services and stop after these services.
+The service will start before these services and stop after these services, if
+they have been added to the runlevel.
 .It Ic provide
 The service provides this virtual service. For example, named provides dns.
 Note that it is not legal to have a virtual and real service with the

--- a/man/openrc.8
+++ b/man/openrc.8
@@ -22,11 +22,11 @@
 .Sh DESCRIPTION
 .Nm
 first stops any services that are not in the specified runlevel unless
---no-stop is specified, then starts any services in the runlevel and
-stacked runlevels added by
+--no-stop is specified, then starts any services added by
 .Nm rc-update
-that are not currently started.
-If no runlevel is specified, we use the current runlevel.
+that are not currently started. Services in a stacked runlevel are started
+before those in the specified runlevel. If no runlevel is specified, we use the
+current runlevel.
 .Pp
 There are some special runlevels that you should be aware of:
 .Bl -tag -width "shutdown"

--- a/man/rc-update.8
+++ b/man/rc-update.8
@@ -77,7 +77,7 @@ This allows inheritance of runlevels.
 .Pp
 If the
 .Fl a, -all
-option is given, we remove the service from all runlevels. This is
+option is given, we remove the service or runlevel from all runlevels. This is
 useful, for example, to clean up the dangling symlinks after a service
 is removed.
 .Sh SEE ALSO

--- a/man/rc-update.8
+++ b/man/rc-update.8
@@ -13,18 +13,18 @@
 .Os OpenRC
 .Sh NAME
 .Nm rc-update
-.Nd add and remove services to and from a runlevel
+.Nd add and remove services or runlevels, to and from runlevels
 .Sh SYNOPSIS
 .Nm
 .Op Fl s , -stack
 .Ic add
-.Ar service
+.Ar dep
 .Op Ar runlevel ...
 .Nm
 .Op Fl s , -stack
 .Op Fl a , -all
 .Ic delete
-.Ar service
+.Ar dep
 .Op Ar runlevel ...
 .Nm
 .Op Fl u , -update
@@ -72,7 +72,7 @@ system clock).
 .Pp
 If the
 .Fl s , -stack
-option is given then we either add or remove the runlevel from the runlevel.
+option is given then the dependency we add or remove must be another runlevel.
 This allows inheritance of runlevels.
 .Pp
 If the

--- a/service-script-guide.md
+++ b/service-script-guide.md
@@ -82,9 +82,10 @@ depend() {
 - `want` is between need and use - try to start coolservice if it is
 	installed on the system, regardless of whether it is in the
 	runlevel, but we don't care if it starts.
-- `before` declares that we need to be started before another service
 - `after` declares that we need to be started after another service, without 
-	creating a dependency (so on calling stop the two are independent)
+	creating a dependency (so on calling stop the two are independent). Has no
+  effect on services in different stacked runlevels.
+- `before` is the reverse of `after`.
 - `provide` allows multiple implementations to provide one service type, e.g.:
 	`provide cron` is set in all cron-daemons, so any one of them started 
 	satisfies a cron dependency


### PR DESCRIPTION
* Documents the order they are started in.
* Documents the limitations of `before`/`after` ordering.
* Clarifies what `rc-update -s <add|delete>` acts on.

I expect `man/rc-update.8: generalize beyond just services` to be the most controversial, since wording is hard.