### PR TITLE
Add support for setting to enable/disable UTMP files creation

### DIFF
--- a/conf.d/bootmisc
+++ b/conf.d/bootmisc
@@ -13,3 +13,6 @@ log_dmesg="YES"
 # This may be useful if you need to compare the current boot to the
 # previous one.
 #previous_dmesg=no
+
+# Whether utmp/wtmp files should be created during boot
+#disable_utmp_creation="no"

--- a/init.d/bootmisc.in
+++ b/init.d/bootmisc.in
@@ -190,14 +190,16 @@ start()
 	fi
 
 	if checkpath -W /var/run; then
-		ebegin "Creating user login records"
-		local xtra=
-		[ "$RC_UNAME" = NetBSD ] && xtra=x
-		for x in "" $xtra; do
-			mkutmp /var/run/utmp$x
-		done
-		[ -e /var/log/wtmp ] || mkutmp /var/log/wtmp
-		eend 0
+		if ! yesno ${disable_utmp_creation:-no}; then
+			ebegin "Creating user login records"
+			local xtra=
+			[ "$RC_UNAME" = NetBSD ] && xtra=x
+			for x in "" $xtra; do
+				mkutmp /var/run/utmp$x
+			done
+			[ -e /var/log/wtmp ] || mkutmp /var/log/wtmp
+			eend 0
+		fi
 
 		mountinfo -q -f tmpfs /var/run || cleanup_var_run_dir
 	fi
@@ -243,7 +245,7 @@ stop()
 {
 	# Write a halt record if we're shutting down
 	if [ "$RC_RUNLEVEL" = shutdown ]; then
-		if [ "$RC_UNAME" = Linux ]; then
+		if [ "$RC_UNAME" = Linux ] && ! yesno ${disable_utmp_creation:-no}; then
 			if [ -x /sbin/halt ]; then
 				halt -w
 			else


### PR DESCRIPTION

musl libc does not natively support UTMP and so some musl-basd distros may not make use of/update UTMP files (i.e. Alpine in the scenario where the utmps package in not installed or configured).

Other Linux distros, especially those using systemd, may be making use of wtmpdb (via systemd-logind) as an alternative.

Therefore it makes sense to provide a configuration setting to prevent OpenRC from creating utmp-related files.