### PR TITLE
cgroups: avoid mounting over an existing cgroup v2 hierarchy

### DIFF
--- a/init.d/cgroups.in
+++ b/init.d/cgroups.in
@@ -72,8 +72,10 @@ cgroup2_base()
 	local base
 	base="$(cgroup2_find_path)"
 	mkdir -p "${base}"
-	mount -t cgroup2 cgroup2 -o "${cgroup_opts},nsdelegate" "${base}" 2> /dev/null ||
-		mount -t cgroup2 cgroup2 -o "${cgroup_opts}" "${base}"
+	if ! mountinfo -q -f '^cgroup2$' "${base}"; then
+		mount -t cgroup2 cgroup2 -o "${cgroup_opts},nsdelegate" "${base}" 2> /dev/null ||
+			mount -t cgroup2 cgroup2 -o "${cgroup_opts}" "${base}"
+	fi
 	return 0
 }
 


### PR DESCRIPTION
When booting a Gentoo Incus container with OpenRC 0.63.1, `/sys/fs/cgroup` is already mounted by the container runtime before the guest init starts. OpenRC mounts another cgroup2 filesystem at the same
mount point, resulting in stacked mounts:

```
~ # mount | grep cgroup
none on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime)
cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime)
```

This PR checks whether a cgroup2 filesystem is already mounted at the target path before attempting to mount it.