### PR TITLE
Fix boundary checks in librc and libeinfo

### DIFF
--- a/src/libeinfo/libeinfo.c
+++ b/src/libeinfo/libeinfo.c
@@ -519,6 +519,7 @@ static int EINFO_PRINTF(3, 0)
 	va_list ap;
 
 	if (last &&
+	    *last &&
 	    !colour_terminal(f) &&
 	    strcmp(last, "ewarn") != 0 &&
 	    last[strlen(last) - 1] == 'n')

--- a/src/librc/librc-daemon.c
+++ b/src/librc/librc-daemon.c
@@ -81,12 +81,12 @@ pid_is_argv(pid_t pid, const char *const *argv)
 	buffer[bytes] = '\0';
 	p = buffer;
 	while (*argv) {
+		if ((unsigned)(p - buffer) >= sizeof(buffer))
+			return false;
 		if (strcmp(*argv, p) != 0)
 			return false;
 		argv++;
 		p += strlen(p) + 1;
-		if ((unsigned)(p - buffer) > sizeof(buffer))
-			return false;
 	}
 	return true;
 }

--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -474,9 +474,9 @@ rc_runlevel_get(void)
 	if ((fp = do_fopenat(rc_dirfd(RC_DIR_SVCDIR), "softlevel", O_RDONLY))) {
 		runlevel = xmalloc(sizeof(char) * PATH_MAX);
 		if (fgets(runlevel, PATH_MAX, fp)) {
-			i = strlen(runlevel) - 1;
-			if (runlevel[i] == '\n')
-				runlevel[i] = 0;
+			i = strlen(runlevel);
+			if (i && runlevel[i - 1] == '\n')
+				runlevel[i - 1] = 0;
 		} else
 			*runlevel = '\0';
 		fclose(fp);


### PR DESCRIPTION
Fix three edge cases that could cause out-of-bounds memory access:

- reject overly long argument lists in `pid_is_argv`;
- handle an empty `EINFO_LASTCMD` safely;
- validate the softlevel length before checking for a trailing newline.