### PR TITLE
librc: avoid a crash when loading malformed deptree files

### DIFF
--- a/src/librc/librc-depend.c
+++ b/src/librc/librc-depend.c
@@ -189,6 +189,8 @@ deptree_load_file(int dirfd, const char *pathname)
 		e = get_shell_value(p);
 		if (!e || *e == '\0')
 			continue;
+		if (!depinfo)
+			continue;
 		if (!deptype || strcmp(deptype->type, type) != 0)
 			deptype = make_deptype(depinfo, type);
 		rc_stringlist_add(deptype->services, e);


### PR DESCRIPTION
A dependency entry without a preceding service leaves depinfo NULL and causes a NULL pointer dereference. Skip such orphaned entries.

To reproduce:
```
printf "%s\n" "depinfo_0_ineed_0='bar'" >/tmp/bad-deptree
/usr/libexec/rc/bin/rc-depend --deptree-file /tmp/bad-deptree foo
```