### PR TITLE
librc: prevent false daemon matches across files

### DIFF
--- a/src/librc/librc-daemon.c
+++ b/src/librc/librc-daemon.c
@@ -316,13 +316,16 @@ rc_find_pids(const char *exec, const char *const *argv, uid_t uid, pid_t pid)
 #endif
 
 static bool
-_match_daemon(const char *svcname, const char *instance, RC_STRINGLIST *match)
+_match_daemon(const char *svcname, const char *instance,
+    const RC_STRINGLIST *match)
 {
 	char *line = NULL;
 	size_t len = 0;
 	FILE *fp;
 	RC_STRING *m;
+	RC_STRINGLIST *match_copy;
 	char *daemon;
+	bool retval;
 
 	xasprintf(&daemon, "%s/%s", svcname, instance);
 	fp = do_fopenat(rc_dirfd(RC_DIR_DAEMONS), daemon, O_RDONLY);
@@ -331,20 +334,26 @@ _match_daemon(const char *svcname, const char *instance, RC_STRINGLIST *match)
 	if (!fp)
 		return false;
 
+	match_copy = rc_stringlist_new();
+	TAILQ_FOREACH(m, match, entries)
+		rc_stringlist_add(match_copy, m->value);
+
 	while (xgetline(&line, &len, fp) != -1) {
-		TAILQ_FOREACH(m, match, entries)
+		TAILQ_FOREACH(m, match_copy, entries)
 		    if (strcmp(line, m->value) == 0) {
-			    TAILQ_REMOVE(match, m, entries);
+			    TAILQ_REMOVE(match_copy, m, entries);
+			    free(m->value);
+			    free(m);
 			    break;
 		    }
-		if (!TAILQ_FIRST(match))
+		if (!TAILQ_FIRST(match_copy))
 			break;
 	}
 	fclose(fp);
 	free(line);
-	if (TAILQ_FIRST(match))
-		return false;
-	return true;
+	retval = !TAILQ_FIRST(match_copy);
+	rc_stringlist_free(match_copy);
+	return retval;
 }
 
 static RC_STRINGLIST *


### PR DESCRIPTION
_match_daemon() removes successful matches from the list while looking for a match. rc_service_daemon_set() and rc_service_started_daemon() call it with the same list for each daemon record file they scan. This causes a criterion matched by one file to be no longer required from the next: partial matches from different files could add up to a successful match.

Fix this by matching each file against a private copy of the list.

To reproduce the problem:
```
export D=/var/tmp/
mkdir -p "$D/openrc/daemons/foo"
printf 'exec=/usr/bin/foo\nargv_0=bar\npidfile=\n' > "$D/openrc/daemons/foo/001"
printf 'exec=/usr/bin/bar\nargv_0=foo\npidfile=\n' > "$D/openrc/daemons/foo/002"
cat >test.c <<EOF
#include <stdio.h>
#include <rc.h>

int main(void)
{
	const char *argv0[] = { "foo", NULL };
	rc_set_user();
	bool r = rc_service_started_daemon("foo", "/usr/bin/foo", argv0, 0);
	printf("%s\n", r ? "true (bug)" : "false");
	return !r;
}
EOF
gcc -o repro test.c -lrc
XDG_RUNTIME_DIR="$D" ./repro
```
Should not match, but it matches before this patch.