### PR TITLE
supervisor=s6: eval command first and don't invoke a shell at run-time

### DIFF
--- a/sh/s6.sh
+++ b/sh/s6.sh
@@ -168,7 +168,9 @@ _s6_servicedir_create() {
 		if test -n "$command_user" ; then
 			echo "s6-setuidgid \"$command_user\""
 		fi
-		echo "sh -c \"exec $command $command_args $command_args_foreground\""
+		eval set -- $command $command_args $command_args_foreground
+		printf '"%s"' $1 ; shift
+		printf ' "%s"' "$@" ; echo
 	} > "$dir/run"
 	chmod 0755 "$dir/run"
 


### PR DESCRIPTION
supervise-daemon uses 'eval' once to evaluate shell constructs in the definition of command, command_args and command_args_foreground. And then it launches $command directly. So it doesn't support deeply nested shell constructs and using a full run-time shell to evaluate $command is unnecessary.
So we do the same when building the run script for s6: we eval at run script build time, and the result invokes $command directly, without going through a shell. This is much cleaner, especially since the rest of the run script is execline i.e. already shell-free.