### PR TITLE
librc: fix service startup without pty & crash regressions

### DIFF
--- a/src/librc/librc.c
+++ b/src/librc/librc.c
@@ -577,8 +577,11 @@ free_rc_dirs(void)
 	X(rc_dirs.confdir);
 	X(rc_dirs.runleveldir);
 	X(rc_path.allocd);
+	/* entries alias freed allocation */
+	rc_path.entries = NULL;
 	X(rc_path.buffer);
 	X(rc_path.fds);
+	rc_path.count = 0;
 #undef X
 }
 

--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -382,17 +382,25 @@ svc_exec(const char *command)
 
 		/* If the below call fails due to not enough ptys then we don't
 		 * prefix the output, but we still work */
-		openpty(&master_tty, &slave_tty, NULL, &tt, &ws);
-		if (master_tty >= 0 && (flags = fcntl(master_tty, F_GETFD, 0)) == 0)
-			fcntl(master_tty, F_SETFD, flags | FD_CLOEXEC);
+		if (openpty(&master_tty, &slave_tty, NULL, &tt, &ws) == 0) {
+			if (master_tty >= 0 &&
+			    (flags = fcntl(master_tty, F_GETFD, 0)) == 0)
+				fcntl(master_tty, F_SETFD,
+				    flags | FD_CLOEXEC);
 
-		if (slave_tty >= 0 && (flags = fcntl(slave_tty, F_GETFD, 0)) == 0)
-			fcntl(slave_tty, F_SETFD, flags | FD_CLOEXEC);
+			if (slave_tty >= 0 &&
+			    (flags = fcntl(slave_tty, F_GETFD, 0)) == 0)
+				fcntl(slave_tty, F_SETFD,
+				    flags | FD_CLOEXEC);
 
-		if ((errno = posix_spawn_file_actions_adddup2(&tty, slave_tty, STDOUT_FILENO))
-				|| (errno = posix_spawn_file_actions_adddup2(&tty, slave_tty, STDERR_FILENO))) {
-			eerror("%s: posix_spawn_file_actions_adddup2: %s", applet, strerror(errno));
-			return 1;
+			if ((errno = posix_spawn_file_actions_adddup2(&tty,
+				    slave_tty, STDOUT_FILENO)) ||
+			    (errno = posix_spawn_file_actions_adddup2(&tty,
+				    slave_tty, STDERR_FILENO))) {
+				eerror("%s: posix_spawn_file_actions_adddup2: %s",
+				    applet, strerror(errno));
+				return 1;
+			}
 		}
 	}
 


### PR DESCRIPTION
This MR fixes two regressions:

- Continue service startup when openpty() fails, restoring the behavior from before 39eb8a9d.
- Avoid a crash during failure cleanup introduced by 68b05704.