### PR TITLE
openrc-init: keep a dummy writer on the control FIFO

### DIFF
--- a/src/openrc-init/openrc-init.c
+++ b/src/openrc-init/openrc-init.c
@@ -285,9 +285,30 @@ static void reap_zombies(int sig RC_UNUSED)
 
 static int open_fifo(const char *path)
 {
+	int dummy_writer;
+	int reader;
+	int saved_errno;
+
 	if (mkfifo(path, 0600) == -1 && errno != EEXIST)
 		return -1;
-	return open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+
+	reader = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+	if (reader == -1)
+		return -1;
+
+	/*
+	 * Keep the dummy writer open for the lifetime of the process so that the
+	 * read end does not continuously report POLLHUP when a client disconnects.
+	 */
+	dummy_writer = open(path, O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+	if (dummy_writer == -1) {
+		saved_errno = errno;
+		close(reader);
+		errno = saved_errno;
+		return -1;
+	}
+
+	return reader;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The init FIFO is opened read-only and monitored with poll(). After a client writes a command and closes the FIFO, Linux continues reporting POLLHUP even after the buffered data has been consumed. Since the main loop only handles POLLIN, poll() then returns immediately on every iteration, causing PID 1 to consume all available CPU time.

This can be reproduced on a system using openrc-init as PID 1 with a harmless unknown command:

    printf invalid > /run/openrc/init.ctl
    top -p 1

Keep a dummy write descriptor open for the lifetime of openrc-init so that disconnecting a client does not leave the read end hung up. Mark the descriptor close-on-exec so it is replaced normally during reexec. A single O_RDWR descriptor would achieve the same, but POSIX leaves O_RDWR on a FIFO undefined, so use a separate write descriptor.

Regression after: afe3eca0 ("openrc-init: use poll for waiting on the fifo")