### PR TITLE
openrc-run: fix memory leaks in PID setup and dependency handling

### DIFF
--- a/src/openrc-run/openrc-run.c
+++ b/src/openrc-run/openrc-run.c
@@ -273,6 +273,7 @@ svc_getenv(const char *svc)
 	}
 
 	free(var);
+	rc_stringlist_free(reexports);
 }
 
 /* Buffer and lock all output messages so that we get readable content */
@@ -996,7 +997,7 @@ load_dep_env(void)
 	TAILQ_FOREACH(svc, depsvcs, entries)
 		svc_getenv(svc->value);
 
-	rc_stringlist_free(services);
+	rc_stringlist_free(depsvcs);
 }
 
 static void
@@ -1314,6 +1315,7 @@ int main(int argc, char **argv)
 	 * for safety.
 	 */
 	setenv("RC_RUNSCRIPT_PID", pidstr, 1);
+	free(pidstr);
 
 	/* eprefix is kinda klunky, but it works for our purposes */
 	if (rc_conf_yesno("rc_parallel")) {


### PR DESCRIPTION
setenv() copies its input, so free the temporary PID string after setting RC_OPENRC_PID and RC_RUNSCRIPT_PID.

Also free the reexport list after importing dependency variables. load_dep_env() similarly leaked its dependency list because it mistakenly freed the unrelated global services list instead.

These leaks were reported by LeakSanitizer during service execution.