### PR TITLE
shared: fix open_rwfifo descriptor handling

### DIFF
--- a/src/shared/helpers.h
+++ b/src/shared/helpers.h
@@ -274,14 +274,14 @@ RC_UNUSED static int open_rwfifo(const char *path, bool nonblock)
 	 * On linux, opening O_RDWR would solve this, but posix
 	 * leaves that behaviour undefined, and for example, hurd
 	 * does not properly handle it. */
-	if ((w = open(path, O_WRONLY | O_NONBLOCK | O_CLOEXEC) == -1)) {
+	if ((w = open(path, O_WRONLY | O_NONBLOCK | O_CLOEXEC)) == -1) {
 		err = errno;
 		goto r_err;
 	}
 
 	if (!nonblock) {
 		int flags = fcntl(r, F_GETFL);
-		if (flags == -1 || fcntl(r, flags & ~O_NONBLOCK) == -1) {
+		if (flags == -1 || fcntl(r, F_SETFL, flags & ~O_NONBLOCK) == -1) {
 			err = errno;
 			goto w_err;
 		}


### PR DESCRIPTION
Fix operator precedence when opening the dummy writer, and pass F_SETFL when clearing O_NONBLOCK on the read descriptor.

Basically, typos introduced in 53cf9bc7d.