### PR TITLE
Support for NO_UMOUNTS variable to netmount

### DIFF
--- a/conf.d/mount-ro
+++ b/conf.d/mount-ro
@@ -1,0 +1,3 @@
+# Stop the unmounting of certain points.
+# This could be useful for some NFS related work.
+#no_umounts="/dir1:/var/dir2"

--- a/conf.d/netmount
+++ b/conf.d/netmount
@@ -45,3 +45,7 @@ rc_need="net"
 # netmount will fail.
 # By default, this is empty.
 #critical_mounts="/home /var"
+#
+# Stop the unmounting of certain points.
+# This could be useful for some NFS related work.
+#no_umounts="/dir1:/var/dir2"

--- a/init.d/netmount.in
+++ b/init.d/netmount.in
@@ -78,7 +78,13 @@ stop()
 		fs="$fs${fs:+|}$x"
 	done
 	[ -n "$fs" ] && fs="^($fs)$"
-	do_unmount -- ${fs:+--fstype-regex} $fs --netdev
+	local IFS="$IFS:" no_umounts_r=
+	for x in $no_umounts; do
+		no_umounts_r="$no_umounts_r${no_umounts_r:+|}$x"
+	done
+	[ -n "$no_umounts_r" ] && no_umounts_r="^($no_umounts_r)$"
+	do_unmount umount ${no_umounts_r:+--skip-point-regex} $no_umounts_r \
+		${fs:+--fstype-regex} $fs --netdev
 	retval=$?
 
 	eoutdent


### PR DESCRIPTION
In `conf.d/localmount`, there is a `no_umounts=` variable, that is used by `init.d/localmount.in`. It excludes the listed mountpoints from automatic unmounting. 

The same  support is already implemented in `init.d/mount-ro.in`. 

This PR adds support for `no_umounts=` variable to `init.d/netmount.in` and documents the variable in `conf.d/netmount` and `conf.d/mount-ro`. 