### PR TITLE
Added missing dmcrypt to localmount use

### DIFF
--- a/init.d/localmount.in
+++ b/init.d/localmount.in
@@ -14,7 +14,7 @@ description="Mounts disks and swap according to /etc/fstab."
 depend()
 {
 	need fsck root
-	use lvm modules
+	use lvm modules dmcrypt
 	after clock lvm modules
 	keyword -docker -podman -jail -lxc -prefix -systemd-nspawn -vserver -wsl
 }


### PR DESCRIPTION
I closed the [original case](https://github.com/OpenRC/openrc/pull/965) since [it seemed to be a bug](https://github.com/OpenRC/openrc/issues/987), but as mentioned in the bug case, adding `dmcrypt` to `use` (instead of `need`) did work on one machine. So even though the bug is still under investigation (configuration issue or OpenRC bug?) the fact of the matter is that dmcrypt should still be added to `use` in localmount. This pull request fixes that. I don' t see why this one can not be merged while the bug is getting investigated.