### PR TITLE
ci: build and test on FreeBSD with GitHub Actions

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -1,0 +1,34 @@
+name: ci_freebsd
+
+on: [push, pull_request]
+
+jobs:
+
+  freebsd:
+    name: FreeBSD ${{ matrix.release }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        release:
+          - '14'
+          - '15'
+    steps:
+    - uses: actions/checkout@v7
+    - name: Build and test
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: ${{ matrix.release }}
+        usesh: true
+        copyback: false
+        cache-after-prepare: true
+        prepare: pkg install -y meson
+        run: |
+          set -e
+          set -u
+          set -x
+          # Carried over from .cirrus.yml, which mounted procfs before the tests.
+          [ -f /proc/curproc ] || mount -t procfs proc /proc
+          meson setup builddir/
+          meson compile -C builddir
+          meson test --verbose -C builddir


### PR DESCRIPTION
Cirrus CI shut down on 2026-06-01.  The last Cirrus check-run here is on
1afc0589 (2026-05-25), named "test
freebsd_instance:freebsd-13-3-release-amd64", and 45 commits have landed
on master since with no FreeBSD result.

This adds .github/workflows/ci-freebsd.yml, shaped like
ci-alpine-linux.yml and ci-ubuntu.yml, running the same three meson
commands ci/cirrus.sh runs, in a FreeBSD VM on a GitHub-hosted runner.

Verified on my fork, both releases green:

  FreeBSD 14.4   2m40s   148/148 linked, Ok: 7, Fail: 0
  FreeBSD 15.1   2m06s   148/148 linked, Ok: 7, Fail: 0

  https://github.com/neilpang/openrc/actions/runs/33625907579

Three differences from .cirrus.yml, all deliberate:

- it installs only meson.  bash, gawk and gsed appear nowhere in the tree
  except .cirrus.yml itself, and the test scripts are all #!/bin/sh.

- no sed replacement.  .cirrus.yml deletes /usr/bin/sed and symlinks
  /usr/local/bin/gsed in its place; I ran the suite both ways in one VM
  and it is 7/7 either way, so the base sed is fine and the base system
  stays intact.

- 14 and 15 both run.  The matrix in .cirrus.yml has two "image:" keys in
  one mapping, so the second silently wins -- the check name on that last
  green run mentions freebsd-13-3 only.

The procfs mount is carried over as-is; I did not test whether it is
still needed.

.cirrus.yml and ci/cirrus.sh are dead now.  I can add a commit removing
them if you want, or leave that to you.
